### PR TITLE
ci: run note pipeline tests in GitHub Actions

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -1,0 +1,24 @@
+name: Node Tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run test suite
+        run: node --test


### PR DESCRIPTION
## Summary
- add a lightweight GitHub Actions workflow for the Node test suite
- run `node --test` on both `push` and `pull_request`
- keep CI dependency-free beyond checkout and setup-node

## Verification
- `node --test`

Closes #17