### PR TITLE
feat: add dashboard review actions for drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,20 @@ node --test
 
 ### 7) 本地打开 dashboard
 
+只读模式：
+
 ```bash
 python3 -m http.server 8008
+```
+
+然后访问：
+
+`http://127.0.0.1:8008/dashboard/index.html`
+
+如果要在 dashboard 里直接做审核状态流转，请使用可写模式：
+
+```bash
+node scripts/dashboard_server.js
 ```
 
 然后访问：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -135,9 +135,25 @@ node --test
 
 ### 7）本地打开 dashboard
 
+只读模式：
+
 ```bash
 python3 -m http.server 8008
 ```
+
+然后访问：
+
+`http://127.0.0.1:8008/dashboard/index.html`
+
+如果要在 dashboard 中直接做审核状态流转，请使用可写模式：
+
+```bash
+node scripts/dashboard_server.js
+```
+
+然后访问：
+
+`http://127.0.0.1:8008/dashboard/index.html`
 
 然后访问：
 

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -78,15 +78,72 @@ function renderReviewStatus(status) {
   return map[status] || status || '草稿';
 }
 
+const appState = {
+  data: null,
+  apiAvailable: false,
+  postFilters: {
+    query: '',
+    account: '',
+    type: 'original'
+  },
+  noteFilters: {
+    theme: '',
+    style: '',
+    reviewStatus: ''
+  },
+  pendingDraftId: null,
+  feedback: ''
+};
+
+function renderModeBadge() {
+  const badge = document.getElementById('dashboardMode');
+  badge.textContent = appState.apiAvailable ? '可操作模式' : '只读模式';
+  badge.className = `mode-badge ${appState.apiAvailable ? 'live' : 'readonly'}`;
+}
+
+function renderFeedback() {
+  document.getElementById('actionFeedback').textContent = appState.feedback || '';
+}
+
+function renderReviewActions(note) {
+  if (!appState.apiAvailable) {
+    return '<div class="review-actions hint">当前是只读模式。请用 `node scripts/dashboard_server.js` 打开 dashboard 以启用审核操作。</div>';
+  }
+
+  const actions = [
+    ['reviewing', '标记审核中'],
+    ['approved', '标记通过'],
+    ['needs_edit', '标记待修改'],
+    ['rejected', '标记拒绝']
+  ];
+
+  return `
+    <div class="review-actions">
+      ${actions.map(([status, label]) => `
+        <button
+          type="button"
+          class="review-action ${note.review_status === status ? 'active' : ''}"
+          data-draft-id="${note.draft_id}"
+          data-review-status="${status}"
+          ${appState.pendingDraftId === note.draft_id ? 'disabled' : ''}
+        >
+          ${label}
+        </button>
+      `).join('')}
+    </div>
+  `;
+}
+
 function renderNotes(notes) {
   document.getElementById('notesList').innerHTML = (notes || [])
     .map((note) => `
       <div class="note-card">
         <h3>${escapeHtml((note.title_options && note.title_options[0]) || '未命名草稿')}</h3>
-        <div class="note-meta">主题：${note.theme || '-'} · 风格：${note.style || '-'} · 状态：${note.status || 'draft'} · 生成时间：${formatTime(note.created_at)}</div>
+        <div class="note-meta">主题：${note.theme || '-'} · 风格：${note.style || '-'} · 状态：${note.status || 'draft'} · 审核状态：<span class="status-chip">${renderReviewStatus(note.review_status)}</span> · 生成时间：${formatTime(note.created_at)}</div>
         <div class="note-meta">Draft：${note.draft_id || '-'} · Brief：${note.brief_id || '-'} · Bundle：${note.bundle_id || '-'} · Run：${note.run_id || '-'}</div>
         <div class="note-preview">${escapeHtml(String(note.body_markdown || '').slice(0, 300))}${String(note.body_markdown || '').length > 300 ? '...' : ''}</div>
         <div class="note-tags">来源帖子数：${note.source_post_count || 0} · 标签：${(note.hashtags || []).join(' ')}</div>
+        ${renderReviewActions(note)}
         ${note.bundle_preview ? `
           <div class="detail-block">
             <div class="detail-title">Bundle 预览</div>
@@ -132,11 +189,35 @@ function renderPosts(posts) {
     .join('');
 }
 
+function renderPostsFromState() {
+  if (!appState.data) return;
+  const filtered = appState.data.posts.filter((p) => {
+    const handle = p.account || p.timeline_owner || p.display_author_handle || p.author_handle;
+    const okAccount = !appState.postFilters.account || handle === appState.postFilters.account;
+    const okType = !appState.postFilters.type || (p.content_type || 'unknown') === appState.postFilters.type;
+    const okText = !appState.postFilters.query || (p.text || '').toLowerCase().includes(appState.postFilters.query);
+    return okAccount && okType && okText;
+  });
+  renderPosts(filtered);
+}
+
+function renderNotesFromState() {
+  if (!appState.data) return;
+  const filtered = (appState.data.notes || []).filter((note) => {
+    const okTheme = !appState.noteFilters.theme || note.theme === appState.noteFilters.theme;
+    const okStyle = !appState.noteFilters.style || note.style === appState.noteFilters.style;
+    const okReviewStatus = !appState.noteFilters.reviewStatus || note.review_status === appState.noteFilters.reviewStatus;
+    return okTheme && okStyle && okReviewStatus;
+  });
+  renderNotes(filtered);
+}
+
 function setupPostFilters(data) {
   const searchInput = document.getElementById('searchInput');
   const accountFilter = document.getElementById('accountFilter');
   const typeFilter = document.getElementById('typeFilter');
 
+  accountFilter.innerHTML = '<option value="">全部账号</option>';
   for (const acc of data.accounts) {
     const option = document.createElement('option');
     option.value = acc.handle;
@@ -144,30 +225,34 @@ function setupPostFilters(data) {
     accountFilter.appendChild(option);
   }
 
-  const apply = () => {
-    const q = searchInput.value.trim().toLowerCase();
-    const account = accountFilter.value;
-    const type = typeFilter.value;
-    const filtered = data.posts.filter((p) => {
-      const handle = p.account || p.timeline_owner || p.display_author_handle || p.author_handle;
-      const okAccount = !account || handle === account;
-      const okType = !type || (p.content_type || 'unknown') === type;
-      const okText = !q || (p.text || '').toLowerCase().includes(q);
-      return okAccount && okType && okText;
-    });
-    renderPosts(filtered);
+  searchInput.value = appState.postFilters.query;
+  accountFilter.value = appState.postFilters.account;
+  typeFilter.value = appState.postFilters.type;
+
+  searchInput.oninput = () => {
+    appState.postFilters.query = searchInput.value.trim().toLowerCase();
+    renderPostsFromState();
+  };
+  accountFilter.onchange = () => {
+    appState.postFilters.account = accountFilter.value;
+    renderPostsFromState();
+  };
+  typeFilter.onchange = () => {
+    appState.postFilters.type = typeFilter.value;
+    renderPostsFromState();
   };
 
-  searchInput.addEventListener('input', apply);
-  accountFilter.addEventListener('change', apply);
-  typeFilter.addEventListener('change', apply);
-  apply();
+  renderPostsFromState();
 }
 
 function setupNoteFilters(data) {
   const themeFilter = document.getElementById('noteThemeFilter');
   const styleFilter = document.getElementById('noteStyleFilter');
   const reviewStatusFilter = document.getElementById('noteReviewStatusFilter');
+
+  themeFilter.innerHTML = '<option value="">全部主题</option>';
+  styleFilter.innerHTML = '<option value="">全部风格</option>';
+  reviewStatusFilter.innerHTML = '<option value="">全部审核状态</option>';
 
   for (const theme of data.filters_meta?.note_themes || []) {
     const option = document.createElement('option');
@@ -190,36 +275,95 @@ function setupNoteFilters(data) {
     reviewStatusFilter.appendChild(option);
   }
 
-  const apply = () => {
-    const theme = themeFilter.value;
-    const style = styleFilter.value;
-    const reviewStatus = reviewStatusFilter.value;
-    const filtered = (data.notes || []).filter((note) => {
-      const okTheme = !theme || note.theme === theme;
-      const okStyle = !style || note.style === style;
-      const okReviewStatus = !reviewStatus || note.review_status === reviewStatus;
-      return okTheme && okStyle && okReviewStatus;
-    });
-    renderNotes(filtered);
+  themeFilter.value = appState.noteFilters.theme;
+  styleFilter.value = appState.noteFilters.style;
+  reviewStatusFilter.value = appState.noteFilters.reviewStatus;
+
+  themeFilter.onchange = () => {
+    appState.noteFilters.theme = themeFilter.value;
+    renderNotesFromState();
+  };
+  styleFilter.onchange = () => {
+    appState.noteFilters.style = styleFilter.value;
+    renderNotesFromState();
+  };
+  reviewStatusFilter.onchange = () => {
+    appState.noteFilters.reviewStatus = reviewStatusFilter.value;
+    renderNotesFromState();
   };
 
-  themeFilter.addEventListener('change', apply);
-  styleFilter.addEventListener('change', apply);
-  reviewStatusFilter.addEventListener('change', apply);
-  apply();
+  renderNotesFromState();
 }
 
-fetch('../data/dashboard/dashboard-data.json')
-  .then((r) => r.json())
+async function loadDashboardData() {
+  try {
+    const response = await fetch('/api/dashboard-data');
+    if (!response.ok) throw new Error(`API ${response.status}`);
+    appState.apiAvailable = true;
+    return await response.json();
+  } catch (_error) {
+    const fallbackResponse = await fetch('../data/dashboard/dashboard-data.json');
+    if (!fallbackResponse.ok) throw new Error(`Dashboard data ${fallbackResponse.status}`);
+    appState.apiAvailable = false;
+    return await fallbackResponse.json();
+  }
+}
+
+function renderDashboard(data) {
+  appState.data = data;
+  document.getElementById('generatedAt').textContent = '数据生成时间：' + formatTime(data.generated_at);
+  renderModeBadge();
+  renderFeedback();
+  renderKpis(data.overview);
+  renderAccounts(data.accounts);
+  renderTop('topLiked', data.top_lists.liked, 'like');
+  renderTop('topViewed', data.top_lists.viewed, 'view');
+  setupPostFilters(data);
+  setupNoteFilters(data);
+}
+
+async function updateReviewStatus(draftId, reviewStatus) {
+  appState.pendingDraftId = draftId;
+  appState.feedback = '正在更新审核状态…';
+  renderFeedback();
+  renderNotesFromState();
+
+  try {
+    const response = await fetch(`/api/drafts/${encodeURIComponent(draftId)}/review-status`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ review_status: reviewStatus })
+    });
+    const payload = await response.json();
+    if (!response.ok || !payload.ok) {
+      throw new Error(payload.message || '状态更新失败');
+    }
+
+    appState.feedback = `已更新 ${draftId} -> ${renderReviewStatus(payload.review_status)}`;
+    const data = await loadDashboardData();
+    renderDashboard(data);
+  } catch (error) {
+    appState.feedback = `状态更新失败：${error.message}`;
+    renderFeedback();
+  } finally {
+    appState.pendingDraftId = null;
+    renderNotesFromState();
+    renderFeedback();
+  }
+}
+
+document.getElementById('notesList').addEventListener('click', async (event) => {
+  const button = event.target.closest('.review-action');
+  if (!button) return;
+
+  await updateReviewStatus(button.dataset.draftId, button.dataset.reviewStatus);
+});
+
+loadDashboardData()
   .then((data) => {
-    document.getElementById('generatedAt').textContent = '数据生成时间：' + formatTime(data.generated_at);
-    renderKpis(data.overview);
-    renderAccounts(data.accounts);
-    renderTop('topLiked', data.top_lists.liked, 'like');
-    renderTop('topViewed', data.top_lists.viewed, 'view');
-    setupPostFilters(data);
-    setupNoteFilters(data);
+    renderDashboard(data);
   })
   .catch((err) => {
     document.getElementById('generatedAt').textContent = '数据加载失败：' + err.message;
+    document.getElementById('dashboardMode').textContent = '加载失败';
   });

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -11,9 +11,13 @@
       <header class="header">
         <div>
           <h1>小红书运营来自 X 星球</h1>
-          <p>运营看板 / Dashboard-v0.1</p>
+          <p>运营看板 / Dashboard-v0.2</p>
         </div>
-        <div class="meta" id="generatedAt">数据加载中…</div>
+        <div class="header-status">
+          <div class="meta" id="generatedAt">数据加载中…</div>
+          <div class="mode-badge" id="dashboardMode">检测模式中…</div>
+          <div class="action-feedback" id="actionFeedback"></div>
+        </div>
       </header>
 
       <section class="kpis" id="kpis"></section>

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -24,8 +24,43 @@ body {
   align-items: end;
   margin-bottom: 20px;
 }
+.header-status {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
 .header h1 { margin: 0 0 6px; font-size: 30px; }
 .header p, .meta { margin: 0; color: var(--muted); }
+.mode-badge,
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+}
+.mode-badge.live {
+  background: rgba(28, 179, 102, 0.12);
+  color: #157347;
+}
+.mode-badge.readonly {
+  background: rgba(255, 90, 54, 0.12);
+  color: #c2410c;
+}
+.status-chip {
+  background: rgba(255, 90, 54, 0.1);
+  color: #c2410c;
+  padding: 3px 8px;
+}
+.action-feedback {
+  color: var(--muted);
+  font-size: 13px;
+  max-width: 420px;
+  text-align: right;
+}
 .kpis {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -91,6 +126,35 @@ input, select {
   color: var(--text);
 }
 .note-tags { margin-top: 12px; color: var(--muted); font-size: 13px; }
+.review-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+.review-actions.hint {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+.review-action {
+  border: 1px solid var(--line);
+  background: white;
+  color: var(--text);
+  border-radius: 999px;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 13px;
+}
+.review-action.active {
+  border-color: var(--brand);
+  color: var(--brand);
+  background: rgba(255, 90, 54, 0.08);
+}
+.review-action:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
 .detail-block {
   margin-top: 12px;
   padding: 12px;
@@ -108,4 +172,6 @@ a { color: var(--brand); text-decoration: none; }
 @media (max-width: 900px) {
   .kpis, .two-col { grid-template-columns: 1fr; }
   .header { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .header-status { align-items: flex-start; }
+  .action-feedback { text-align: left; }
 }

--- a/scripts/build_dashboard_data.js
+++ b/scripts/build_dashboard_data.js
@@ -2,14 +2,6 @@
 const fs = require('fs');
 const path = require('path');
 
-const projectRoot = path.resolve(__dirname, '..');
-const accountsRoot = path.join(projectRoot, 'data', 'x', 'accounts');
-const outputPath = path.join(projectRoot, 'data', 'dashboard', 'dashboard-data.json');
-const notesDraftsRoot = path.join(projectRoot, 'notes', 'drafts');
-const notesBriefsRoot = path.join(projectRoot, 'notes', 'briefs');
-const notesBundlesRoot = path.join(projectRoot, 'notes', 'bundles');
-const notesRunsRoot = path.join(projectRoot, 'notes', 'runs');
-
 function ensureDir(dir) {
   fs.mkdirSync(dir, { recursive: true });
 }
@@ -160,7 +152,14 @@ function normalizeReviewStatus(status) {
   return status || 'draft';
 }
 
-function main() {
+function buildDashboardData(projectRoot = path.resolve(__dirname, '..')) {
+  const accountsRoot = path.join(projectRoot, 'data', 'x', 'accounts');
+  const outputPath = path.join(projectRoot, 'data', 'dashboard', 'dashboard-data.json');
+  const notesDraftsRoot = path.join(projectRoot, 'notes', 'drafts');
+  const notesBriefsRoot = path.join(projectRoot, 'notes', 'briefs');
+  const notesBundlesRoot = path.join(projectRoot, 'notes', 'bundles');
+  const notesRunsRoot = path.join(projectRoot, 'notes', 'runs');
+
   const handles = fs.existsSync(accountsRoot)
     ? fs.readdirSync(accountsRoot).filter((name) => fs.statSync(path.join(accountsRoot, name)).isDirectory())
     : [];
@@ -224,7 +223,21 @@ function main() {
 
   ensureDir(path.dirname(outputPath));
   fs.writeFileSync(outputPath, JSON.stringify(dashboard, null, 2) + '\n', 'utf8');
+  return {
+    outputPath,
+    dashboard
+  };
+}
+
+function main() {
+  const { outputPath } = buildDashboardData();
   console.log(outputPath);
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  buildDashboardData
+};

--- a/scripts/dashboard_server.js
+++ b/scripts/dashboard_server.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+const { buildDashboardData } = require('./build_dashboard_data');
+const { updateDraftReviewStatus } = require('../src/review_action_store');
+
+function sendJson(res, statusCode, payload) {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(payload, null, 2));
+}
+
+function sendText(res, statusCode, contentType, body) {
+  res.writeHead(statusCode, { 'Content-Type': contentType });
+  res.end(body);
+}
+
+function getContentType(filePath) {
+  if (filePath.endsWith('.html')) return 'text/html; charset=utf-8';
+  if (filePath.endsWith('.css')) return 'text/css; charset=utf-8';
+  if (filePath.endsWith('.js')) return 'application/javascript; charset=utf-8';
+  if (filePath.endsWith('.json')) return 'application/json; charset=utf-8';
+  return 'text/plain; charset=utf-8';
+}
+
+function serveStatic(projectRoot, pathname, res) {
+  let filePath = null;
+
+  if (pathname === '/') {
+    res.writeHead(302, { Location: '/dashboard/index.html' });
+    res.end();
+    return true;
+  }
+
+  if (pathname.startsWith('/dashboard/')) {
+    filePath = path.join(projectRoot, pathname.slice(1));
+  } else if (pathname.startsWith('/data/')) {
+    filePath = path.join(projectRoot, pathname.slice(1));
+  }
+
+  if (!filePath || !fs.existsSync(filePath) || fs.statSync(filePath).isDirectory()) {
+    return false;
+  }
+
+  sendText(res, 200, getContentType(filePath), fs.readFileSync(filePath));
+  return true;
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      try {
+        const raw = Buffer.concat(chunks).toString('utf8').trim();
+        resolve(raw ? JSON.parse(raw) : {});
+      } catch (error) {
+        reject(error);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function createDashboardServer(projectRoot) {
+  return http.createServer(async (req, res) => {
+    const url = new URL(req.url, 'http://127.0.0.1');
+
+    if (req.method === 'GET' && url.pathname === '/api/dashboard-data') {
+      try {
+        const { dashboard } = buildDashboardData(projectRoot);
+        return sendJson(res, 200, dashboard);
+      } catch (error) {
+        return sendJson(res, 500, { ok: false, message: error.message });
+      }
+    }
+
+    if (req.method === 'POST' && /^\/api\/drafts\/[^/]+\/review-status$/.test(url.pathname)) {
+      try {
+        const draftId = decodeURIComponent(url.pathname.split('/')[3]);
+        const body = await readBody(req);
+        const { draft, previousStatus } = updateDraftReviewStatus(projectRoot, {
+          draftId,
+          reviewStatus: body.review_status,
+          source: 'dashboard'
+        });
+        const { dashboard } = buildDashboardData(projectRoot);
+        return sendJson(res, 200, {
+          ok: true,
+          draft_id: draftId,
+          previous_review_status: previousStatus,
+          review_status: draft.review_status,
+          review_updated_at: draft.review_updated_at,
+          dashboard_generated_at: dashboard.generated_at
+        });
+      } catch (error) {
+        return sendJson(res, 400, { ok: false, message: error.message });
+      }
+    }
+
+    if (req.method === 'GET' && serveStatic(projectRoot, url.pathname, res)) {
+      return;
+    }
+
+    sendJson(res, 404, { ok: false, message: 'Not found' });
+  });
+}
+
+function main() {
+  const projectRoot = path.resolve(__dirname, '..');
+  const port = Number(process.env.PORT || 8008);
+
+  buildDashboardData(projectRoot);
+
+  const server = createDashboardServer(projectRoot);
+  server.listen(port, () => {
+    console.log(`Dashboard server running at http://127.0.0.1:${port}/dashboard/index.html`);
+  });
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  createDashboardServer
+};

--- a/src/review_action_store.js
+++ b/src/review_action_store.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const path = require('path');
+const { REVIEW_STATUSES, normalizeReviewStatus } = require('./review_status');
+
+const DASHBOARD_ACTION_STATUSES = ['reviewing', 'approved', 'needs_edit', 'rejected'];
+
+function getDraftPath(projectRoot, draftId) {
+  return path.join(projectRoot, 'notes', 'drafts', `${draftId}.json`);
+}
+
+function readDraft(projectRoot, draftId) {
+  const draftPath = getDraftPath(projectRoot, draftId);
+  if (!fs.existsSync(draftPath)) {
+    throw new Error(`Draft not found: ${draftId}`);
+  }
+
+  return {
+    draftPath,
+    draft: JSON.parse(fs.readFileSync(draftPath, 'utf8'))
+  };
+}
+
+function writeJsonAtomic(filePath, payload) {
+  const tempPath = `${filePath}.tmp`;
+  fs.writeFileSync(tempPath, JSON.stringify(payload, null, 2) + '\n', 'utf8');
+  fs.renameSync(tempPath, filePath);
+}
+
+function updateDraftReviewStatus(projectRoot, { draftId, reviewStatus, source = 'dashboard' }) {
+  if (!draftId) {
+    throw new Error('draftId is required');
+  }
+
+  if (!reviewStatus || !REVIEW_STATUSES.includes(reviewStatus)) {
+    throw new Error(`Invalid review status: ${reviewStatus}`);
+  }
+
+  if (!DASHBOARD_ACTION_STATUSES.includes(reviewStatus)) {
+    throw new Error(`Review status is not allowed from dashboard actions: ${reviewStatus}`);
+  }
+
+  const { draftPath, draft } = readDraft(projectRoot, draftId);
+  const previousStatus = normalizeReviewStatus(draft.review_status || draft.status);
+  const updatedAt = new Date().toISOString();
+  const nextHistory = Array.isArray(draft.review_history) ? [...draft.review_history] : [];
+
+  nextHistory.push({
+    from: previousStatus,
+    to: reviewStatus,
+    source,
+    updated_at: updatedAt
+  });
+
+  const nextDraft = {
+    ...draft,
+    review_status: reviewStatus,
+    review_updated_at: updatedAt,
+    review_history: nextHistory
+  };
+
+  writeJsonAtomic(draftPath, nextDraft);
+
+  return {
+    draftPath,
+    previousStatus,
+    draft: nextDraft
+  };
+}
+
+module.exports = {
+  DASHBOARD_ACTION_STATUSES,
+  getDraftPath,
+  readDraft,
+  updateDraftReviewStatus
+};

--- a/test/dashboard_server.test.js
+++ b/test/dashboard_server.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { createDashboardServer } = require('../scripts/dashboard_server');
+
+function makeTempProject() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'xhs-dashboard-server-'));
+}
+
+function writeJson(filePath, data) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+function writeText(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+test('dashboard server updates review status and rebuilds dashboard data', async () => {
+  const tempRoot = makeTempProject();
+  writeText(path.join(tempRoot, 'dashboard', 'index.html'), '<!doctype html><title>ok</title>');
+  writeText(path.join(tempRoot, 'dashboard', 'app.js'), 'console.log("ok");');
+  writeText(path.join(tempRoot, 'dashboard', 'styles.css'), 'body {}');
+
+  writeJson(path.join(tempRoot, 'notes', 'drafts', 'draft-1.json'), {
+    draft_id: 'draft-1',
+    brief_id: 'brief-1',
+    bundle_id: 'bundle-1',
+    theme: 'AI coding',
+    style: 'trend-analysis',
+    body_markdown: 'hello',
+    source_posts: [],
+    status: 'draft',
+    review_status: 'draft',
+    created_at: '2026-03-24T10:00:00.000Z'
+  });
+
+  const server = createDashboardServer(tempRoot);
+  await new Promise((resolve) => server.listen(0, resolve));
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/drafts/draft-1/review-status`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ review_status: 'reviewing' })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.review_status, 'reviewing');
+
+    const persisted = JSON.parse(fs.readFileSync(path.join(tempRoot, 'notes', 'drafts', 'draft-1.json'), 'utf8'));
+    const dashboard = JSON.parse(fs.readFileSync(path.join(tempRoot, 'data', 'dashboard', 'dashboard-data.json'), 'utf8'));
+
+    assert.equal(persisted.review_status, 'reviewing');
+    assert.equal(dashboard.notes[0].review_status, 'reviewing');
+    assert.ok(dashboard.filters_meta.review_statuses.includes('reviewing'));
+  } finally {
+    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  }
+});

--- a/test/review_action_store.test.js
+++ b/test/review_action_store.test.js
@@ -1,0 +1,57 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { updateDraftReviewStatus } = require('../src/review_action_store');
+
+function makeTempProject() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'xhs-review-store-'));
+}
+
+function writeJson(filePath, data) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+test('updateDraftReviewStatus persists status change and appends review history', () => {
+  const tempRoot = makeTempProject();
+  const draftPath = path.join(tempRoot, 'notes', 'drafts', 'draft-1.json');
+
+  writeJson(draftPath, {
+    draft_id: 'draft-1',
+    review_status: 'draft',
+    status: 'draft',
+    body_markdown: 'hello'
+  });
+
+  const result = updateDraftReviewStatus(tempRoot, {
+    draftId: 'draft-1',
+    reviewStatus: 'approved'
+  });
+
+  const persisted = JSON.parse(fs.readFileSync(draftPath, 'utf8'));
+  assert.equal(result.previousStatus, 'draft');
+  assert.equal(persisted.review_status, 'approved');
+  assert.ok(persisted.review_updated_at);
+  assert.equal(persisted.review_history.length, 1);
+  assert.equal(persisted.review_history[0].from, 'draft');
+  assert.equal(persisted.review_history[0].to, 'approved');
+  assert.equal(persisted.review_history[0].source, 'dashboard');
+});
+
+test('updateDraftReviewStatus rejects unsupported dashboard statuses', () => {
+  const tempRoot = makeTempProject();
+  writeJson(path.join(tempRoot, 'notes', 'drafts', 'draft-2.json'), {
+    draft_id: 'draft-2',
+    review_status: 'draft',
+    status: 'draft'
+  });
+
+  assert.throws(() => {
+    updateDraftReviewStatus(tempRoot, {
+      draftId: 'draft-2',
+      reviewStatus: 'published'
+    });
+  }, /not allowed from dashboard actions/);
+});


### PR DESCRIPTION
## Summary
- add a lightweight local dashboard server with review-state writeback APIs
- let operators change draft review status from the dashboard UI
- persist review status changes with review timestamps and history, then rebuild dashboard data
- update docs and add automated coverage for the new review flow

## Verification
- `node --test`
- browser smoke test against local dashboard server

Closes #14