### PR TITLE
feat: add note artifact archival workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,27 @@ node src/run_draft_composer.js notes/briefs/<brief_id>.json notes/bundles/<bundl
 node --test
 ```
 
-### 7) 本地打开 dashboard
+### 7) 预览或归档历史 note artifacts
+
+默认是 dry-run，只预览将被归档的历史 artifacts：
+
+```bash
+node scripts/archive_note_artifacts.js --keep-drafts 20
+```
+
+确认无误后再执行实际归档：
+
+```bash
+node scripts/archive_note_artifacts.js --keep-drafts 20 --apply
+```
+
+如果要给其他脚本消费结果，可以输出 JSON：
+
+```bash
+node scripts/archive_note_artifacts.js --keep-drafts 20 --json
+```
+
+### 8) 本地打开 dashboard
 
 只读模式：
 
@@ -196,6 +216,7 @@ node src/run_from_raw.js samples/raw/sama-raw.json sama
 
 - [Note Pipeline Refactor Task List](./docs/note-pipeline-refactor-task-list.md)
 - [Note Pipeline Contracts](./docs/note-pipeline-contracts.md)
+- [Note Artifact Retention Rules](./docs/note-artifact-retention.md)
 
 ## 相关仓库
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -133,7 +133,27 @@ node src/run_draft_composer.js notes/briefs/<brief_id>.json notes/bundles/<bundl
 node --test
 ```
 
-### 7）本地打开 dashboard
+### 7）预览或归档历史 note artifacts
+
+默认是 dry-run，只预览将被归档的历史 artifacts：
+
+```bash
+node scripts/archive_note_artifacts.js --keep-drafts 20
+```
+
+确认无误后再执行实际归档：
+
+```bash
+node scripts/archive_note_artifacts.js --keep-drafts 20 --apply
+```
+
+如果要给其他脚本消费结果，可以输出 JSON：
+
+```bash
+node scripts/archive_note_artifacts.js --keep-drafts 20 --json
+```
+
+### 8）本地打开 dashboard
 
 只读模式：
 
@@ -150,10 +170,6 @@ python3 -m http.server 8008
 ```bash
 node scripts/dashboard_server.js
 ```
-
-然后访问：
-
-`http://127.0.0.1:8008/dashboard/index.html`
 
 然后访问：
 
@@ -198,6 +214,7 @@ node src/run_from_raw.js samples/raw/sama-raw.json sama
 
 - [Note Pipeline 模块化重构任务清单](./docs/note-pipeline-refactor-task-list.md)
 - [Note Pipeline Contracts](./docs/note-pipeline-contracts.md)
+- [Note Artifact Retention Rules](./docs/note-artifact-retention.md)
 
 ## 相关仓库
 

--- a/docs/note-artifact-retention.md
+++ b/docs/note-artifact-retention.md
@@ -1,0 +1,63 @@
+# Note Artifact Retention Rules
+
+## Goal
+
+Keep the active `notes/` working set small enough for day-to-day review while preserving historical artifacts in a recoverable archive.
+
+## First-pass rule
+
+The current rule is intentionally simple and safe:
+
+1. Keep the latest `N` draft lineages in the active `notes/` directories.
+2. A kept draft lineage includes:
+   - `notes/drafts/<draft_id>.json`
+   - `notes/drafts/<draft_id>.md` if present
+   - the linked `brief_id`
+   - the linked `bundle_id`
+   - any `run` artifact that references the kept `draft_id`
+3. Any bundle / brief / draft / run artifact not referenced by those kept lineages is treated as historical and becomes an archive candidate.
+
+Default `N` is `20`, but operators can override it.
+
+## Safety model
+
+- The archive flow is **dry-run by default**
+- Files are **never deleted automatically**
+- `--apply` moves files into `notes/archive/<archive-id>/...`
+- Every apply run writes an `archive-manifest.json` with:
+  - the retention rule used
+  - the kept lineage IDs
+  - the exact source and destination of each archived file
+
+This keeps historical artifacts recoverable and auditable.
+
+## Commands
+
+Preview what would be archived:
+
+```bash
+node scripts/archive_note_artifacts.js --keep-drafts 20
+```
+
+Apply the archive:
+
+```bash
+node scripts/archive_note_artifacts.js --keep-drafts 20 --apply
+```
+
+Machine-readable preview:
+
+```bash
+node scripts/archive_note_artifacts.js --keep-drafts 20 --json
+```
+
+## Restore flow
+
+To restore archived artifacts, move the files listed in the relevant `archive-manifest.json` back into:
+
+- `notes/bundles/`
+- `notes/briefs/`
+- `notes/drafts/`
+- `notes/runs/`
+
+The first-pass goal is safe archiving, not aggressive deletion. Restore therefore stays explicit and operator-driven.

--- a/scripts/archive_note_artifacts.js
+++ b/scripts/archive_note_artifacts.js
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const ARTIFACT_TYPES = ['bundles', 'briefs', 'drafts', 'runs'];
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function readArtifactDir(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => {
+      const filePath = path.join(dir, name);
+      return {
+        filePath,
+        fileName: name,
+        payload: readJson(filePath)
+      };
+    });
+}
+
+function parseArgs(argv) {
+  const options = {
+    keepDrafts: 20,
+    apply: false,
+    json: false
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--apply') {
+      options.apply = true;
+      continue;
+    }
+    if (arg === '--json') {
+      options.json = true;
+      continue;
+    }
+    if (arg === '--keep-drafts') {
+      const value = Number(argv[i + 1]);
+      if (!Number.isInteger(value) || value < 0) {
+        throw new Error('--keep-drafts must be a non-negative integer');
+      }
+      options.keepDrafts = value;
+      i += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function buildArchiveId(now = new Date()) {
+  return `archive-${now.toISOString().replace(/[:.]/g, '-').replace('T', '_')}`;
+}
+
+function sortByCreatedDesc(items, getDateValue) {
+  return [...items].sort((a, b) => {
+    const aValue = new Date(getDateValue(a) || 0).getTime();
+    const bValue = new Date(getDateValue(b) || 0).getTime();
+    return bValue - aValue;
+  });
+}
+
+function collectArtifacts(projectRoot) {
+  const notesRoot = path.join(projectRoot, 'notes');
+  return {
+    notesRoot,
+    drafts: readArtifactDir(path.join(notesRoot, 'drafts')),
+    briefs: readArtifactDir(path.join(notesRoot, 'briefs')),
+    bundles: readArtifactDir(path.join(notesRoot, 'bundles')),
+    runs: readArtifactDir(path.join(notesRoot, 'runs'))
+  };
+}
+
+function buildKeepSets({ drafts, runs, keepDrafts }) {
+  const sortedDrafts = sortByCreatedDesc(drafts, (item) => item.payload.created_at);
+  const keptDrafts = sortedDrafts.slice(0, keepDrafts);
+  const keptDraftIds = new Set(keptDrafts.map((item) => item.payload.draft_id).filter(Boolean));
+  const keptBriefIds = new Set();
+  const keptBundleIds = new Set();
+  const keptRunIds = new Set();
+
+  for (const draft of keptDrafts) {
+    if (draft.payload.brief_id) keptBriefIds.add(draft.payload.brief_id);
+    if (draft.payload.bundle_id) keptBundleIds.add(draft.payload.bundle_id);
+    if (draft.payload.source_brief_id) keptBriefIds.add(draft.payload.source_brief_id);
+    if (draft.payload.source_bundle_id) keptBundleIds.add(draft.payload.source_bundle_id);
+  }
+
+  for (const run of runs) {
+    if (run.payload.draft_id && keptDraftIds.has(run.payload.draft_id)) {
+      keptRunIds.add(run.payload.run_id);
+    }
+  }
+
+  return {
+    keptDraftIds,
+    keptBriefIds,
+    keptBundleIds,
+    keptRunIds
+  };
+}
+
+function listArchiveCandidates(artifacts, keepSets) {
+  const candidates = [];
+
+  for (const draft of artifacts.drafts) {
+    const draftId = draft.payload.draft_id;
+    if (!keepSets.keptDraftIds.has(draftId)) {
+      candidates.push({
+        type: 'drafts',
+        id: draftId,
+        filePath: draft.filePath,
+        fileName: draft.fileName
+      });
+
+      const markdownPath = draft.filePath.replace(/\.json$/, '.md');
+      if (fs.existsSync(markdownPath)) {
+        candidates.push({
+          type: 'drafts',
+          id: draftId,
+          filePath: markdownPath,
+          fileName: path.basename(markdownPath)
+        });
+      }
+    }
+  }
+
+  for (const brief of artifacts.briefs) {
+    const briefId = brief.payload.brief_id;
+    if (!keepSets.keptBriefIds.has(briefId)) {
+      candidates.push({
+        type: 'briefs',
+        id: briefId,
+        filePath: brief.filePath,
+        fileName: brief.fileName
+      });
+    }
+  }
+
+  for (const bundle of artifacts.bundles) {
+    const bundleId = bundle.payload.bundle_id || bundle.payload.selection_id;
+    if (!keepSets.keptBundleIds.has(bundleId)) {
+      candidates.push({
+        type: 'bundles',
+        id: bundleId,
+        filePath: bundle.filePath,
+        fileName: bundle.fileName
+      });
+    }
+  }
+
+  for (const run of artifacts.runs) {
+    const runId = run.payload.run_id;
+    if (!keepSets.keptRunIds.has(runId)) {
+      candidates.push({
+        type: 'runs',
+        id: runId,
+        filePath: run.filePath,
+        fileName: run.fileName
+      });
+    }
+  }
+
+  return candidates;
+}
+
+function summarizeCandidates(candidates) {
+  return ARTIFACT_TYPES.reduce((acc, type) => {
+    acc[type] = candidates.filter((item) => item.type === type).length;
+    return acc;
+  }, {});
+}
+
+function archiveNoteArtifacts(projectRoot, options = {}) {
+  const keepDrafts = options.keepDrafts ?? 20;
+  const apply = Boolean(options.apply);
+  const now = options.now || new Date();
+  const archiveId = buildArchiveId(now);
+  const artifacts = collectArtifacts(projectRoot);
+  const keepSets = buildKeepSets({ ...artifacts, keepDrafts });
+  const candidates = listArchiveCandidates(artifacts, keepSets);
+  const summary = summarizeCandidates(candidates);
+  const archiveRoot = path.join(artifacts.notesRoot, 'archive', archiveId);
+
+  const manifest = {
+    archive_id: archiveId,
+    created_at: now.toISOString(),
+    mode: apply ? 'apply' : 'dry-run',
+    rule: {
+      keep_latest_draft_lineages: keepDrafts,
+      archive_scope: 'archive any bundle/brief/draft/run artifact not referenced by the kept draft lineages'
+    },
+    kept: {
+      draft_ids: [...keepSets.keptDraftIds],
+      brief_ids: [...keepSets.keptBriefIds],
+      bundle_ids: [...keepSets.keptBundleIds],
+      run_ids: [...keepSets.keptRunIds]
+    },
+    archived_counts: summary,
+    archived_files: candidates.map((item) => ({
+      type: item.type,
+      id: item.id,
+      source: path.relative(projectRoot, item.filePath),
+      destination: path.relative(projectRoot, path.join(archiveRoot, item.type, item.fileName))
+    }))
+  };
+
+  if (apply) {
+    ensureDir(archiveRoot);
+
+    if (candidates.length > 0) {
+      for (const type of ARTIFACT_TYPES) {
+        ensureDir(path.join(archiveRoot, type));
+      }
+
+      for (const candidate of candidates) {
+        fs.renameSync(candidate.filePath, path.join(archiveRoot, candidate.type, candidate.fileName));
+      }
+    }
+
+    fs.writeFileSync(
+      path.join(archiveRoot, 'archive-manifest.json'),
+      JSON.stringify(manifest, null, 2) + '\n',
+      'utf8'
+    );
+  }
+
+  return {
+    ok: true,
+    apply,
+    archiveRoot: path.relative(projectRoot, archiveRoot),
+    keepDrafts,
+    archivedCounts: summary,
+    archivedFileCount: candidates.length,
+    manifest
+  };
+}
+
+function printSummary(result) {
+  const lines = [
+    result.apply ? 'Archive apply mode completed.' : 'Archive dry-run completed.',
+    `Keep latest draft lineages: ${result.keepDrafts}`,
+    `Archive root: ${result.archiveRoot}`,
+    `Archived files: ${result.archivedFileCount}`,
+    `  bundles: ${result.archivedCounts.bundles}`,
+    `  briefs: ${result.archivedCounts.briefs}`,
+    `  drafts: ${result.archivedCounts.drafts}`,
+    `  runs: ${result.archivedCounts.runs}`
+  ];
+
+  if (!result.apply) {
+    lines.push('No files were moved. Re-run with --apply to archive the candidates.');
+  }
+
+  console.log(lines.join('\n'));
+}
+
+function main() {
+  const projectRoot = path.resolve(__dirname, '..');
+  const options = parseArgs(process.argv.slice(2));
+  const result = archiveNoteArtifacts(projectRoot, options);
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  printSummary(result);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  archiveNoteArtifacts,
+  buildArchiveId,
+  buildKeepSets,
+  collectArtifacts,
+  listArchiveCandidates,
+  parseArgs
+};

--- a/test/archive_note_artifacts.test.js
+++ b/test/archive_note_artifacts.test.js
@@ -1,0 +1,116 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { archiveNoteArtifacts } = require('../scripts/archive_note_artifacts');
+
+function makeTempProject() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'xhs-archive-test-'));
+}
+
+function writeJson(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(payload, null, 2) + '\n', 'utf8');
+}
+
+function writeText(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf8');
+}
+
+function seedLineage(tempRoot, suffix, createdAt) {
+  writeJson(path.join(tempRoot, 'notes', 'drafts', `draft-${suffix}.json`), {
+    draft_id: `draft-${suffix}`,
+    brief_id: `brief-${suffix}`,
+    bundle_id: `bundle-${suffix}`,
+    created_at: createdAt
+  });
+  writeText(path.join(tempRoot, 'notes', 'drafts', `draft-${suffix}.md`), `# ${suffix}`);
+  writeJson(path.join(tempRoot, 'notes', 'briefs', `brief-${suffix}.json`), {
+    brief_id: `brief-${suffix}`,
+    bundle_id: `bundle-${suffix}`,
+    created_at: createdAt
+  });
+  writeJson(path.join(tempRoot, 'notes', 'bundles', `bundle-${suffix}.json`), {
+    bundle_id: `bundle-${suffix}`,
+    created_at: createdAt
+  });
+  writeJson(path.join(tempRoot, 'notes', 'runs', `run-${suffix}.json`), {
+    run_id: `run-${suffix}`,
+    draft_id: `draft-${suffix}`,
+    created_at: createdAt
+  });
+}
+
+test('archiveNoteArtifacts dry-run reports candidates without moving files', () => {
+  const tempRoot = makeTempProject();
+  seedLineage(tempRoot, 'old', '2026-03-20T10:00:00.000Z');
+  seedLineage(tempRoot, 'new', '2026-03-21T10:00:00.000Z');
+
+  const result = archiveNoteArtifacts(tempRoot, {
+    keepDrafts: 1,
+    apply: false,
+    now: new Date('2026-03-25T03:30:00.000Z')
+  });
+
+  assert.equal(result.archivedCounts.drafts, 2);
+  assert.equal(result.archivedCounts.briefs, 1);
+  assert.equal(result.archivedCounts.bundles, 1);
+  assert.equal(result.archivedCounts.runs, 1);
+  assert.ok(fs.existsSync(path.join(tempRoot, 'notes', 'drafts', 'draft-old.json')));
+  assert.ok(!fs.existsSync(path.join(tempRoot, result.archiveRoot)));
+});
+
+test('archiveNoteArtifacts apply moves historical artifacts into archive manifest', () => {
+  const tempRoot = makeTempProject();
+  seedLineage(tempRoot, 'old', '2026-03-20T10:00:00.000Z');
+  seedLineage(tempRoot, 'new', '2026-03-21T10:00:00.000Z');
+
+  const result = archiveNoteArtifacts(tempRoot, {
+    keepDrafts: 1,
+    apply: true,
+    now: new Date('2026-03-25T03:30:00.000Z')
+  });
+
+  const archiveRoot = path.join(tempRoot, result.archiveRoot);
+  const manifestPath = path.join(archiveRoot, 'archive-manifest.json');
+
+  assert.ok(fs.existsSync(manifestPath));
+  assert.ok(!fs.existsSync(path.join(tempRoot, 'notes', 'drafts', 'draft-old.json')));
+  assert.ok(fs.existsSync(path.join(archiveRoot, 'drafts', 'draft-old.json')));
+  assert.ok(fs.existsSync(path.join(archiveRoot, 'drafts', 'draft-old.md')));
+  assert.ok(fs.existsSync(path.join(tempRoot, 'notes', 'drafts', 'draft-new.json')));
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  assert.equal(manifest.mode, 'apply');
+  assert.equal(manifest.rule.keep_latest_draft_lineages, 1);
+  assert.ok(manifest.archived_files.some((item) => item.source === 'notes/drafts/draft-old.json'));
+});
+
+test('archiveNoteArtifacts apply writes manifest even when there are no archive candidates', () => {
+  const tempRoot = makeTempProject();
+  seedLineage(tempRoot, 'only', '2026-03-21T10:00:00.000Z');
+
+  const result = archiveNoteArtifacts(tempRoot, {
+    keepDrafts: 5,
+    apply: true,
+    now: new Date('2026-03-25T03:30:00.000Z')
+  });
+
+  const archiveRoot = path.join(tempRoot, result.archiveRoot);
+  const manifestPath = path.join(archiveRoot, 'archive-manifest.json');
+
+  assert.equal(result.archivedFileCount, 0);
+  assert.ok(fs.existsSync(manifestPath));
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  assert.equal(manifest.mode, 'apply');
+  assert.deepEqual(manifest.archived_counts, {
+    bundles: 0,
+    briefs: 0,
+    drafts: 0,
+    runs: 0
+  });
+  assert.deepEqual(manifest.archived_files, []);
+});


### PR DESCRIPTION
## Summary
- add a dry-run-first archive CLI for note artifacts with keep-draft lineage rules
- document retention and restore flow for `notes/` artifacts
- cover dry-run, apply, and zero-candidate apply with tests

## Testing
- node --test

Closes #16
