### PR TITLE
feat: add publish ready payload generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ node scripts/dashboard_server.js
 
 ## 其他常用命令
 
+### 从已通过的 draft 生成 publish-ready payload
+
+```bash
+node scripts/create_publish_ready.js <draft_id> --prepared-by xiangbaqiu
+```
+
 ### 从已有 raw 重新生成结构化数据
 
 ```bash
@@ -201,6 +207,7 @@ node src/run_from_raw.js samples/raw/sama-raw.json sama
 - `notes/briefs/*.json`
 - `notes/drafts/*.json`
 - `notes/drafts/*.md`
+- `notes/publish-ready/*.json`
 - `notes/runs/*.json`
 
 ## 默认约定

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -177,6 +177,12 @@ node scripts/dashboard_server.js
 
 ## 其他常用命令
 
+### 从已通过的 draft 生成 publish-ready payload
+
+```bash
+node scripts/create_publish_ready.js <draft_id> --prepared-by xiangbaqiu
+```
+
 ### 从已有 raw 重新生成结构化数据
 
 ```bash
@@ -199,6 +205,7 @@ node src/run_from_raw.js samples/raw/sama-raw.json sama
 - `notes/briefs/*.json`
 - `notes/drafts/*.json`
 - `notes/drafts/*.md`
+- `notes/publish-ready/*.json`
 - `notes/runs/*.json`
 
 ## 默认约定

--- a/scripts/create_publish_ready.js
+++ b/scripts/create_publish_ready.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { createPublishReady } = require('../src/publish_ready_builder');
+
+function parseArgs(argv) {
+  const options = {
+    draftId: argv[0] || null,
+    preparedBy: null,
+    title: null,
+    coverText: null,
+    bodyMarkdown: null,
+    hashtags: null
+  };
+
+  for (let i = 1; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--prepared-by') {
+      options.preparedBy = argv[i + 1] || null;
+      i += 1;
+      continue;
+    }
+    if (arg === '--title') {
+      options.title = argv[i + 1] || null;
+      i += 1;
+      continue;
+    }
+    if (arg === '--cover-text') {
+      options.coverText = argv[i + 1] || null;
+      i += 1;
+      continue;
+    }
+    if (arg === '--body-file') {
+      const filePath = argv[i + 1];
+      if (!filePath) {
+        throw new Error('--body-file requires a file path');
+      }
+      options.bodyMarkdown = fs.readFileSync(path.resolve(filePath), 'utf8');
+      i += 1;
+      continue;
+    }
+    if (arg === '--hashtags') {
+      const value = argv[i + 1] || '';
+      options.hashtags = value.split(',').map((item) => item.trim()).filter(Boolean);
+      i += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function printUsage() {
+  console.log(JSON.stringify({
+    ok: false,
+    message: 'Usage: node scripts/create_publish_ready.js <draft_id> [--prepared-by <name>] [--title <text>] [--cover-text <text>] [--body-file <path>] [--hashtags tag1,tag2]'
+  }, null, 2));
+}
+
+function main() {
+  const projectRoot = path.resolve(__dirname, '..');
+  const options = parseArgs(process.argv.slice(2));
+
+  if (!options.draftId) {
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = createPublishReady(projectRoot, options);
+  console.log(JSON.stringify({
+    ok: true,
+    draft_id: result.publishReady.draft_id,
+    publish_ready_id: result.publishReady.publish_ready_id,
+    path: result.filePath,
+    source_review_status: result.publishReady.source_review_status
+  }, null, 2));
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.log(JSON.stringify({
+      ok: false,
+      message: error.message
+    }, null, 2));
+    process.exit(1);
+  }
+}

--- a/src/note_artifact_io.js
+++ b/src/note_artifact_io.js
@@ -46,6 +46,11 @@ function writeRunSummary(baseDir, runSummary) {
   return writeJson(filePath, runSummary);
 }
 
+function writePublishReady(baseDir, publishReady) {
+  const filePath = path.join(baseDir, 'notes', 'publish-ready', `${publishReady.draft_id}.json`);
+  return writeJson(filePath, publishReady);
+}
+
 module.exports = {
   ensureDir,
   writeJson,
@@ -55,5 +60,6 @@ module.exports = {
   writeBrief,
   writeDraft,
   writeDraftMarkdown,
-  writeRunSummary
+  writeRunSummary,
+  writePublishReady
 };

--- a/src/publish_ready_builder.js
+++ b/src/publish_ready_builder.js
@@ -1,0 +1,97 @@
+const fs = require('fs');
+const path = require('path');
+const { writePublishReady } = require('./note_artifact_io');
+const { normalizeReviewStatus } = require('./review_status');
+
+function getDraftPath(baseDir, draftId) {
+  return path.join(baseDir, 'notes', 'drafts', `${draftId}.json`);
+}
+
+function readDraft(baseDir, draftId) {
+  const draftPath = getDraftPath(baseDir, draftId);
+  if (!fs.existsSync(draftPath)) {
+    throw new Error(`Draft not found: ${draftId}`);
+  }
+
+  return JSON.parse(fs.readFileSync(draftPath, 'utf8'));
+}
+
+function normalizeOptionalText(value) {
+  if (value == null) return null;
+  const text = String(value).trim();
+  return text ? text : null;
+}
+
+function normalizeStringList(values) {
+  if (!Array.isArray(values)) return [];
+  return values
+    .map((value) => normalizeOptionalText(value))
+    .filter(Boolean);
+}
+
+function buildPublishReadyId(draftId) {
+  return `publish-ready-${draftId}`;
+}
+
+function pickDefaultTitle(draft) {
+  return normalizeOptionalText(Array.isArray(draft.title_options) ? draft.title_options[0] : null);
+}
+
+function pickDefaultCoverText(draft) {
+  return normalizeOptionalText(Array.isArray(draft.cover_text_options) ? draft.cover_text_options[0] : null);
+}
+
+function buildPublishReadyPayload(draft, options = {}) {
+  const reviewStatus = normalizeReviewStatus(draft.review_status || draft.status);
+  if (reviewStatus !== 'approved') {
+    throw new Error(`Draft is not approved: ${draft.draft_id}`);
+  }
+
+  const preparedAt = (options.now || new Date()).toISOString();
+
+  return {
+    publish_ready_id: buildPublishReadyId(draft.draft_id),
+    draft_id: draft.draft_id,
+    brief_id: draft.brief_id || draft.source_brief_id || null,
+    bundle_id: draft.bundle_id || draft.source_bundle_id || null,
+    theme: draft.theme || null,
+    style: draft.style || null,
+    title: normalizeOptionalText(options.title) || pickDefaultTitle(draft),
+    cover_text: normalizeOptionalText(options.coverText) || pickDefaultCoverText(draft),
+    body_markdown: normalizeOptionalText(options.bodyMarkdown) || draft.body_markdown || '',
+    hashtags: normalizeStringList(options.hashtags || draft.hashtags),
+    source_posts: Array.isArray(draft.source_posts) ? draft.source_posts : [],
+    review_annotation: draft.review_annotation || null,
+    prepared_at: preparedAt,
+    prepared_by: normalizeOptionalText(options.preparedBy),
+    source_review_status: reviewStatus,
+    editable_fields: ['title', 'body_markdown', 'hashtags', 'cover_text']
+  };
+}
+
+function createPublishReady(baseDir, options = {}) {
+  const draftId = normalizeOptionalText(options.draftId);
+  if (!draftId) {
+    throw new Error('draftId is required');
+  }
+
+  const draft = readDraft(baseDir, draftId);
+  const publishReady = buildPublishReadyPayload(draft, options);
+  const filePath = writePublishReady(baseDir, publishReady);
+
+  return {
+    draft,
+    publishReady,
+    filePath
+  };
+}
+
+module.exports = {
+  buildPublishReadyId,
+  buildPublishReadyPayload,
+  createPublishReady,
+  getDraftPath,
+  normalizeOptionalText,
+  normalizeStringList,
+  readDraft
+};

--- a/test/publish_ready_builder.test.js
+++ b/test/publish_ready_builder.test.js
@@ -1,0 +1,125 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { createPublishReady } = require('../src/publish_ready_builder');
+
+function makeTempProject() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'xhs-publish-ready-'));
+}
+
+function writeJson(filePath, data) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n', 'utf8');
+}
+
+function copyFile(src, dest) {
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(src, dest);
+}
+
+function scaffoldCliProject(tempRoot) {
+  const repoRoot = path.resolve(__dirname, '..');
+  for (const file of [
+    'note_artifact_io.js',
+    'publish_ready_builder.js',
+    'review_status.js'
+  ]) {
+    copyFile(path.join(repoRoot, 'src', file), path.join(tempRoot, 'src', file));
+  }
+
+  copyFile(
+    path.join(repoRoot, 'scripts', 'create_publish_ready.js'),
+    path.join(tempRoot, 'scripts', 'create_publish_ready.js')
+  );
+}
+
+function execJsonAllowFailure(command, args, cwd) {
+  try {
+    return JSON.parse(execFileSync(command, args, { cwd, encoding: 'utf8' }));
+  } catch (error) {
+    return JSON.parse(error.stdout);
+  }
+}
+
+test('createPublishReady writes a publish-ready artifact for an approved draft', () => {
+  const tempRoot = makeTempProject();
+  writeJson(path.join(tempRoot, 'notes', 'drafts', 'draft-1.json'), {
+    draft_id: 'draft-1',
+    brief_id: 'brief-1',
+    bundle_id: 'bundle-1',
+    theme: 'AI coding',
+    style: 'trend-analysis',
+    title_options: ['标题 A', '标题 B'],
+    cover_text_options: ['封面 A'],
+    body_markdown: '正文内容',
+    hashtags: ['#AI', '#小红书运营'],
+    source_posts: [{ tweet_id: '1', url: 'https://x.com/sama/1' }],
+    review_status: 'approved',
+    review_annotation: {
+      reviewer_note: '方向可发',
+      operator_identity: 'xiangbaqiu'
+    }
+  });
+
+  const result = createPublishReady(tempRoot, {
+    draftId: 'draft-1',
+    preparedBy: 'xiangbaqiu',
+    now: new Date('2026-03-25T04:00:00.000Z')
+  });
+
+  const persisted = JSON.parse(fs.readFileSync(result.filePath, 'utf8'));
+  assert.equal(persisted.publish_ready_id, 'publish-ready-draft-1');
+  assert.equal(persisted.draft_id, 'draft-1');
+  assert.equal(persisted.title, '标题 A');
+  assert.equal(persisted.cover_text, '封面 A');
+  assert.equal(persisted.body_markdown, '正文内容');
+  assert.deepEqual(persisted.hashtags, ['#AI', '#小红书运营']);
+  assert.equal(persisted.prepared_by, 'xiangbaqiu');
+  assert.equal(persisted.source_review_status, 'approved');
+});
+
+test('createPublishReady rejects drafts that are not approved', () => {
+  const tempRoot = makeTempProject();
+  writeJson(path.join(tempRoot, 'notes', 'drafts', 'draft-2.json'), {
+    draft_id: 'draft-2',
+    review_status: 'reviewing'
+  });
+
+  assert.throws(() => {
+    createPublishReady(tempRoot, { draftId: 'draft-2' });
+  }, /not approved/);
+});
+
+test('create_publish_ready CLI creates an artifact and returns usage errors when missing args', () => {
+  const tempRoot = makeTempProject();
+  scaffoldCliProject(tempRoot);
+
+  writeJson(path.join(tempRoot, 'notes', 'drafts', 'draft-3.json'), {
+    draft_id: 'draft-3',
+    brief_id: 'brief-3',
+    bundle_id: 'bundle-3',
+    title_options: ['默认标题'],
+    cover_text_options: ['默认封面'],
+    body_markdown: '默认正文',
+    hashtags: ['#AI'],
+    review_status: 'approved'
+  });
+
+  const okResult = execJsonAllowFailure('node', [
+    path.join(tempRoot, 'scripts', 'create_publish_ready.js'),
+    'draft-3',
+    '--prepared-by',
+    'xiangbaqiu'
+  ], tempRoot);
+  assert.equal(okResult.ok, true);
+  assert.ok(fs.existsSync(okResult.path));
+
+  const usageResult = execJsonAllowFailure('node', [
+    path.join(tempRoot, 'scripts', 'create_publish_ready.js')
+  ], tempRoot);
+  assert.equal(usageResult.ok, false);
+  assert.match(usageResult.message, /Usage/);
+});


### PR DESCRIPTION
## Summary
- add a publish-ready builder for approved drafts plus unified artifact writing
- add a CLI to materialize `notes/publish-ready/<draft_id>.json`
- document the command and cover helper/CLI behavior with tests

## Testing
- node --test

Closes #24
