### PR TITLE
feat: add publish record writeback flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ node scripts/dashboard_server.js
 node scripts/create_publish_ready.js <draft_id> --prepared-by xiangbaqiu
 ```
 
+### 记录真实发布结果并回写 published 状态
+
+```bash
+node scripts/record_publish_result.js <draft_id> --published-by xiangbaqiu --platform-url https://www.xiaohongshu.com/explore/<note_id>
+```
+
 ### 从已有 raw 重新生成结构化数据
 
 ```bash
@@ -208,6 +214,7 @@ node src/run_from_raw.js samples/raw/sama-raw.json sama
 - `notes/drafts/*.json`
 - `notes/drafts/*.md`
 - `notes/publish-ready/*.json`
+- `notes/publish-records/*.json`
 - `notes/runs/*.json`
 
 ## 默认约定

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -183,6 +183,12 @@ node scripts/dashboard_server.js
 node scripts/create_publish_ready.js <draft_id> --prepared-by xiangbaqiu
 ```
 
+### 记录真实发布结果并回写 published 状态
+
+```bash
+node scripts/record_publish_result.js <draft_id> --published-by xiangbaqiu --platform-url https://www.xiaohongshu.com/explore/<note_id>
+```
+
 ### 从已有 raw 重新生成结构化数据
 
 ```bash
@@ -206,6 +212,7 @@ node src/run_from_raw.js samples/raw/sama-raw.json sama
 - `notes/drafts/*.json`
 - `notes/drafts/*.md`
 - `notes/publish-ready/*.json`
+- `notes/publish-records/*.json`
 - `notes/runs/*.json`
 
 ## 默认约定

--- a/scripts/record_publish_result.js
+++ b/scripts/record_publish_result.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { recordPublishResult } = require('../src/publish_record_store');
+
+function parseArgs(argv) {
+  const options = {
+    draftId: argv[0] || null,
+    publishedBy: null,
+    publishedAt: null,
+    platform: null,
+    platformUrl: null,
+    platformPostId: null,
+    note: null,
+    finalTitle: null,
+    finalBodyMarkdown: null,
+    finalHashtags: null
+  };
+
+  for (let i = 1; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--published-by') {
+      options.publishedBy = argv[i + 1] || null;
+      i += 1;
+      continue;
+    }
+    if (arg === '--published-at') {
+      options.publishedAt = argv[i + 1] || null;
+      i += 1;
+      continue;
+    }
+    if (arg === '--platform') {
+      options.platform = argv[i + 1] || null;
+      i += 1;
+      continue;
+    }
+    if (arg === '--platform-url') {
+      options.platformUrl = argv[i + 1] || null;
+      i += 1;
+      continue;
+    }
+    if (arg === '--platform-post-id') {
+      options.platformPostId = argv[i + 1] || null;
+      i += 1;
+      continue;
+    }
+    if (arg === '--note') {
+      options.note = argv[i + 1] || null;
+      i += 1;
+      continue;
+    }
+    if (arg === '--final-title') {
+      options.finalTitle = argv[i + 1] || null;
+      i += 1;
+      continue;
+    }
+    if (arg === '--final-body-file') {
+      const filePath = argv[i + 1];
+      if (!filePath) {
+        throw new Error('--final-body-file requires a file path');
+      }
+      options.finalBodyMarkdown = fs.readFileSync(path.resolve(filePath), 'utf8');
+      i += 1;
+      continue;
+    }
+    if (arg === '--final-hashtags') {
+      const value = argv[i + 1] || '';
+      options.finalHashtags = value.split(',').map((item) => item.trim()).filter(Boolean);
+      i += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function printUsage() {
+  console.log(JSON.stringify({
+    ok: false,
+    message: 'Usage: node scripts/record_publish_result.js <draft_id> --published-by <name> --platform-url <url> [--published-at <iso>] [--platform <name>] [--platform-post-id <id>] [--note <text>] [--final-title <text>] [--final-body-file <path>] [--final-hashtags tag1,tag2]'
+  }, null, 2));
+}
+
+function main() {
+  const projectRoot = path.resolve(__dirname, '..');
+  const options = parseArgs(process.argv.slice(2));
+
+  if (!options.draftId || !options.publishedBy || !options.platformUrl) {
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = recordPublishResult(projectRoot, options);
+  console.log(JSON.stringify({
+    ok: true,
+    draft_id: result.draft.draft_id,
+    publish_record_id: result.publishRecord.publish_record_id,
+    path: result.publishRecordPath,
+    published_at: result.publishRecord.published_at,
+    published_url: result.publishRecord.platform_post_url
+  }, null, 2));
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.log(JSON.stringify({
+      ok: false,
+      message: error.message
+    }, null, 2));
+    process.exit(1);
+  }
+}

--- a/src/note_artifact_io.js
+++ b/src/note_artifact_io.js
@@ -51,6 +51,11 @@ function writePublishReady(baseDir, publishReady) {
   return writeJson(filePath, publishReady);
 }
 
+function writePublishRecord(baseDir, publishRecord) {
+  const filePath = path.join(baseDir, 'notes', 'publish-records', `${publishRecord.publish_record_id}.json`);
+  return writeJson(filePath, publishRecord);
+}
+
 module.exports = {
   ensureDir,
   writeJson,
@@ -61,5 +66,6 @@ module.exports = {
   writeDraft,
   writeDraftMarkdown,
   writeRunSummary,
-  writePublishReady
+  writePublishReady,
+  writePublishRecord
 };

--- a/src/publish_record_store.js
+++ b/src/publish_record_store.js
@@ -1,0 +1,162 @@
+const fs = require('fs');
+const path = require('path');
+const { writePublishRecord } = require('./note_artifact_io');
+const {
+  getDraftPath,
+  normalizeOptionalText,
+  normalizeStringList,
+  readDraft
+} = require('./publish_ready_builder');
+const { normalizeReviewStatus } = require('./review_status');
+
+function getPublishReadyPath(baseDir, draftId) {
+  return path.join(baseDir, 'notes', 'publish-ready', `${draftId}.json`);
+}
+
+function readPublishReady(baseDir, draftId) {
+  const publishReadyPath = getPublishReadyPath(baseDir, draftId);
+  if (!fs.existsSync(publishReadyPath)) {
+    throw new Error(`Publish-ready payload not found: ${draftId}`);
+  }
+
+  return JSON.parse(fs.readFileSync(publishReadyPath, 'utf8'));
+}
+
+function writeJsonAtomic(filePath, payload) {
+  const tempPath = `${filePath}.tmp`;
+  fs.writeFileSync(tempPath, JSON.stringify(payload, null, 2) + '\n', 'utf8');
+  fs.renameSync(tempPath, filePath);
+}
+
+function normalizeBodyMarkdown(value, fallback = '') {
+  if (value == null) return fallback;
+  return String(value);
+}
+
+function buildPublishRecordId(now = new Date()) {
+  return `publish-${now.getTime()}`;
+}
+
+function buildPublishAnnotation({ publishedBy, publishedAt, note }) {
+  return {
+    reviewer_note: note || 'Published to Xiaohongshu',
+    edit_suggestion: null,
+    rejection_reason: null,
+    operator_identity: publishedBy,
+    review_status: 'published',
+    updated_at: publishedAt
+  };
+}
+
+function buildPublishRecord({ draft, publishReady, options, publishedAt }) {
+  const platform = normalizeOptionalText(options.platform) || 'xiaohongshu';
+
+  return {
+    publish_record_id: buildPublishRecordId(new Date(publishedAt)),
+    draft_id: draft.draft_id,
+    publish_ready_id: publishReady.publish_ready_id,
+    platform,
+    published_at: publishedAt,
+    published_by: normalizeOptionalText(options.publishedBy),
+    platform_post_id: normalizeOptionalText(options.platformPostId),
+    platform_post_url: normalizeOptionalText(options.platformUrl),
+    final_title: normalizeOptionalText(options.finalTitle) || publishReady.title || null,
+    final_body_markdown: normalizeBodyMarkdown(options.finalBodyMarkdown, publishReady.body_markdown || ''),
+    final_hashtags: normalizeStringList(options.finalHashtags || publishReady.hashtags),
+    notes: normalizeOptionalText(options.note)
+  };
+}
+
+function recordPublishResult(baseDir, options = {}) {
+  const draftId = normalizeOptionalText(options.draftId);
+  if (!draftId) {
+    throw new Error('draftId is required');
+  }
+
+  const publishedBy = normalizeOptionalText(options.publishedBy);
+  if (!publishedBy) {
+    throw new Error('publishedBy is required');
+  }
+
+  const platformUrl = normalizeOptionalText(options.platformUrl);
+  if (!platformUrl) {
+    throw new Error('platformUrl is required');
+  }
+
+  const publishedAtInput = normalizeOptionalText(options.publishedAt);
+  const publishedAtDate = publishedAtInput ? new Date(publishedAtInput) : (options.now || new Date());
+  if (Number.isNaN(publishedAtDate.getTime())) {
+    throw new Error(`Invalid publishedAt: ${options.publishedAt}`);
+  }
+
+  const draftPath = getDraftPath(baseDir, draftId);
+  const draft = readDraft(baseDir, draftId);
+  const publishReady = readPublishReady(baseDir, draftId);
+  const previousStatus = normalizeReviewStatus(draft.review_status || draft.status);
+
+  if (previousStatus !== 'approved') {
+    throw new Error(`Draft is not approved: ${draftId}`);
+  }
+
+  const publishedAt = publishedAtDate.toISOString();
+  const publishRecord = buildPublishRecord({
+    draft,
+    publishReady,
+    options: {
+      ...options,
+      publishedBy,
+      platformUrl
+    },
+    publishedAt
+  });
+  const annotation = buildPublishAnnotation({
+    publishedBy,
+    publishedAt,
+    note: publishRecord.notes
+  });
+  const nextHistory = Array.isArray(draft.review_history) ? [...draft.review_history] : [];
+
+  nextHistory.push({
+    from: previousStatus,
+    to: 'published',
+    source: options.source || 'publish_recorder',
+    updated_at: publishedAt,
+    annotation
+  });
+
+  const nextDraft = {
+    ...draft,
+    review_status: 'published',
+    review_updated_at: publishedAt,
+    review_annotation: annotation,
+    review_history: nextHistory,
+    published_at: publishedAt,
+    published_by: publishedBy,
+    publish_record_id: publishRecord.publish_record_id,
+    publish_ready_id: publishReady.publish_ready_id,
+    published_platform: publishRecord.platform,
+    published_url: platformUrl,
+    platform_post_id: publishRecord.platform_post_id
+  };
+
+  const publishRecordPath = writePublishRecord(baseDir, publishRecord);
+  writeJsonAtomic(draftPath, nextDraft);
+
+  return {
+    draftPath,
+    draft: nextDraft,
+    publishReady,
+    publishRecord,
+    publishRecordPath,
+    previousStatus
+  };
+}
+
+module.exports = {
+  buildPublishAnnotation,
+  buildPublishRecord,
+  buildPublishRecordId,
+  getPublishReadyPath,
+  readPublishReady,
+  recordPublishResult
+};

--- a/test/publish_record_store.test.js
+++ b/test/publish_record_store.test.js
@@ -1,0 +1,159 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { recordPublishResult } = require('../src/publish_record_store');
+
+function makeTempProject() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'xhs-publish-record-'));
+}
+
+function writeJson(filePath, data) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n', 'utf8');
+}
+
+function copyFile(src, dest) {
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(src, dest);
+}
+
+function scaffoldCliProject(tempRoot) {
+  const repoRoot = path.resolve(__dirname, '..');
+  for (const file of [
+    'note_artifact_io.js',
+    'publish_ready_builder.js',
+    'publish_record_store.js',
+    'review_status.js'
+  ]) {
+    copyFile(path.join(repoRoot, 'src', file), path.join(tempRoot, 'src', file));
+  }
+
+  copyFile(
+    path.join(repoRoot, 'scripts', 'record_publish_result.js'),
+    path.join(tempRoot, 'scripts', 'record_publish_result.js')
+  );
+}
+
+function execJsonAllowFailure(command, args, cwd) {
+  try {
+    return JSON.parse(execFileSync(command, args, { cwd, encoding: 'utf8' }));
+  } catch (error) {
+    return JSON.parse(error.stdout);
+  }
+}
+
+test('recordPublishResult writes publish record and updates draft to published', () => {
+  const tempRoot = makeTempProject();
+  writeJson(path.join(tempRoot, 'notes', 'drafts', 'draft-1.json'), {
+    draft_id: 'draft-1',
+    review_status: 'approved',
+    review_history: [
+      {
+        from: 'reviewing',
+        to: 'approved',
+        source: 'dashboard',
+        updated_at: '2026-03-25T03:50:00.000Z',
+        annotation: null
+      }
+    ]
+  });
+  writeJson(path.join(tempRoot, 'notes', 'publish-ready', 'draft-1.json'), {
+    publish_ready_id: 'publish-ready-draft-1',
+    draft_id: 'draft-1',
+    title: '准备发布标题',
+    body_markdown: '准备发布正文',
+    hashtags: ['#AI'],
+    source_review_status: 'approved'
+  });
+
+  const result = recordPublishResult(tempRoot, {
+    draftId: 'draft-1',
+    publishedBy: 'xiangbaqiu',
+    publishedAt: '2026-03-25T04:10:00.000Z',
+    platformUrl: 'https://www.xiaohongshu.com/explore/demo',
+    platformPostId: 'xhs-demo-1',
+    note: '发布前做了轻微措辞修改'
+  });
+
+  const publishRecord = JSON.parse(fs.readFileSync(result.publishRecordPath, 'utf8'));
+  const draft = JSON.parse(fs.readFileSync(path.join(tempRoot, 'notes', 'drafts', 'draft-1.json'), 'utf8'));
+
+  assert.equal(publishRecord.publish_ready_id, 'publish-ready-draft-1');
+  assert.equal(publishRecord.published_by, 'xiangbaqiu');
+  assert.equal(publishRecord.platform_post_url, 'https://www.xiaohongshu.com/explore/demo');
+  assert.equal(draft.review_status, 'published');
+  assert.equal(draft.publish_record_id, publishRecord.publish_record_id);
+  assert.equal(draft.publish_ready_id, 'publish-ready-draft-1');
+  assert.equal(draft.published_url, 'https://www.xiaohongshu.com/explore/demo');
+  assert.equal(draft.review_history.at(-1).from, 'approved');
+  assert.equal(draft.review_history.at(-1).to, 'published');
+  assert.equal(draft.review_history.at(-1).source, 'publish_recorder');
+  assert.equal(draft.review_history.at(-1).annotation.operator_identity, 'xiangbaqiu');
+});
+
+test('recordPublishResult rejects missing publish-ready payload and non-approved drafts', () => {
+  const tempRoot = makeTempProject();
+  writeJson(path.join(tempRoot, 'notes', 'drafts', 'draft-2.json'), {
+    draft_id: 'draft-2',
+    review_status: 'reviewing'
+  });
+
+  assert.throws(() => {
+    recordPublishResult(tempRoot, {
+      draftId: 'draft-2',
+      publishedBy: 'xiangbaqiu',
+      platformUrl: 'https://www.xiaohongshu.com/explore/demo'
+    });
+  }, /Publish-ready payload not found|not approved/);
+
+  writeJson(path.join(tempRoot, 'notes', 'publish-ready', 'draft-2.json'), {
+    publish_ready_id: 'publish-ready-draft-2',
+    draft_id: 'draft-2'
+  });
+
+  assert.throws(() => {
+    recordPublishResult(tempRoot, {
+      draftId: 'draft-2',
+      publishedBy: 'xiangbaqiu',
+      platformUrl: 'https://www.xiaohongshu.com/explore/demo'
+    });
+  }, /not approved/);
+});
+
+test('record_publish_result CLI writes publish record and returns usage errors', () => {
+  const tempRoot = makeTempProject();
+  scaffoldCliProject(tempRoot);
+
+  writeJson(path.join(tempRoot, 'notes', 'drafts', 'draft-3.json'), {
+    draft_id: 'draft-3',
+    review_status: 'approved'
+  });
+  writeJson(path.join(tempRoot, 'notes', 'publish-ready', 'draft-3.json'), {
+    publish_ready_id: 'publish-ready-draft-3',
+    draft_id: 'draft-3',
+    title: '默认标题',
+    body_markdown: '默认正文',
+    hashtags: ['#AI']
+  });
+
+  const okResult = execJsonAllowFailure('node', [
+    path.join(tempRoot, 'scripts', 'record_publish_result.js'),
+    'draft-3',
+    '--published-by',
+    'xiangbaqiu',
+    '--platform-url',
+    'https://www.xiaohongshu.com/explore/demo'
+  ], tempRoot);
+  assert.equal(okResult.ok, true);
+  assert.ok(fs.existsSync(okResult.path));
+
+  const usageResult = execJsonAllowFailure('node', [
+    path.join(tempRoot, 'scripts', 'record_publish_result.js'),
+    'draft-3'
+  ], tempRoot);
+  assert.equal(usageResult.ok, false);
+  assert.match(usageResult.message, /Usage/);
+});


### PR DESCRIPTION
## Summary
- add a publish record store that writes publish artifacts and updates the source draft to `published`
- add a CLI to record a real publish result with platform metadata
- document the command and cover helper/CLI behavior with tests

## Testing
- node --test

Closes #25
