### PR TITLE
feat: show publish traceability in dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - 生成标准化 `posts.jsonl` / `state.json` / `summary.json`
 - 通过模块化 note pipeline 生成 bundle / brief / draft / run summary
 - 在本地 dashboard 中查看草稿及其 lineage（bundle / brief / draft）
+- 在本地 dashboard 中查看审核状态、publish-ready、publish record 等发布追踪信息
 - 内置 Node test coverage，覆盖 builders 和 pipeline integration
 
 ## 当前 note pipeline

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,6 +22,7 @@
 - 生成标准化 `posts.jsonl` / `state.json` / `summary.json`
 - 通过模块化 note pipeline 生成 bundle / brief / draft / run summary
 - 在本地 dashboard 中查看草稿及其 lineage（bundle / brief / draft）
+- 在本地 dashboard 中查看审核状态、publish-ready、publish record 等发布追踪信息
 - 内置 Node 测试，覆盖 builders 和 pipeline integration
 
 ## 当前 note pipeline

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -78,6 +78,46 @@ function renderReviewStatus(status) {
   return map[status] || status || '草稿';
 }
 
+function renderPublishTraceability(note) {
+  const publishReady = note.publish_ready;
+  const publishRecord = note.publish_record;
+
+  if (!publishReady && !publishRecord && note.review_status !== 'approved' && note.review_status !== 'published') {
+    return '';
+  }
+
+  const rows = [];
+
+  if (publishReady) {
+    rows.push(`<div class="note-meta">发布包：已生成 · ID：${publishReady.publish_ready_id || '-'} · 准备时间：${formatTime(publishReady.prepared_at)} · 准备人：${publishReady.prepared_by || '-'}</div>`);
+    if (publishReady.title) {
+      rows.push(`<div class="note-meta">发布标题：${escapeHtml(publishReady.title)}</div>`);
+    }
+  } else if (note.review_status === 'approved') {
+    rows.push('<div class="note-meta">发布包：未生成</div>');
+  }
+
+  if (publishRecord) {
+    const url = publishRecord.platform_post_url
+      ? `<a href="${publishRecord.platform_post_url}" target="_blank">查看发布链接</a>`
+      : '无链接';
+    rows.push(`<div class="note-meta">发布记录：已记录 · ID：${publishRecord.publish_record_id || '-'} · 平台：${publishRecord.platform || '-'} · 发布时间：${formatTime(publishRecord.published_at)} · 发布人：${publishRecord.published_by || '-'}</div>`);
+    rows.push(`<div class="note-meta">外部链接：${url}${publishRecord.platform_post_id ? ` · 平台 ID：${escapeHtml(publishRecord.platform_post_id)}` : ''}</div>`);
+    if (publishRecord.notes) {
+      rows.push(`<div class="note-meta">发布备注：${escapeHtml(publishRecord.notes)}</div>`);
+    }
+  } else if (note.review_status === 'published') {
+    rows.push('<div class="note-meta">发布记录：缺失，请检查历史 artifact</div>');
+  }
+
+  return `
+    <div class="detail-block">
+      <div class="detail-title">发布追踪</div>
+      ${rows.join('')}
+    </div>
+  `;
+}
+
 const appState = {
   data: null,
   apiAvailable: false,
@@ -229,6 +269,7 @@ function renderNotes(notes) {
         ${renderReviewAnnotationForm(note)}
         ${renderReviewActions(note)}
         ${renderReviewAnnotation(note)}
+        ${renderPublishTraceability(note)}
         ${note.bundle_preview ? `
           <div class="detail-block">
             <div class="detail-title">Bundle 预览</div>

--- a/scripts/build_dashboard_data.js
+++ b/scripts/build_dashboard_data.js
@@ -33,14 +33,18 @@ function readJsonDir(dir) {
     .filter((name) => name.endsWith('.json'))
     .map((name) => readJson(path.join(dir, name)))
     .filter(Boolean)
-    .sort((a, b) => new Date(b.created_at || 0) - new Date(a.created_at || 0));
+    .sort((a, b) => {
+      const aTime = new Date(a.published_at || a.prepared_at || a.created_at || a.review_updated_at || 0).getTime();
+      const bTime = new Date(b.published_at || b.prepared_at || b.created_at || b.review_updated_at || 0).getTime();
+      return bTime - aTime;
+    });
 }
 
 function indexById(items, keyResolver) {
   const map = new Map();
   for (const item of items) {
     const key = keyResolver(item);
-    if (key) map.set(key, item);
+    if (key && !map.has(key)) map.set(key, item);
   }
   return map;
 }
@@ -85,13 +89,35 @@ function summarizeAccount(handle, posts) {
   };
 }
 
-function buildNoteLineage(draft, briefsById, bundlesById, runsByDraftId) {
+function buildNoteLineage(draft, briefsById, bundlesById, runsByDraftId, publishReadyByDraftId, publishRecordsByDraftId) {
   const briefId = draft.brief_id || draft.source_brief_id || null;
   const bundleId = draft.bundle_id || draft.source_bundle_id || draft.source_selection_id || null;
   const draftId = draft.draft_id || draft.note_id || null;
   const brief = briefId ? briefsById.get(briefId) || null : null;
   const bundle = bundleId ? bundlesById.get(bundleId) || null : null;
   const run = draftId ? runsByDraftId.get(draftId) || null : null;
+  const publishReady = draftId ? publishReadyByDraftId.get(draftId) || null : null;
+  const publishRecord = draftId ? publishRecordsByDraftId.get(draftId) || null : null;
+  const publishReadyPreview = publishReady || draft.publish_ready_id
+    ? {
+        publish_ready_id: publishReady?.publish_ready_id || draft.publish_ready_id || null,
+        prepared_at: publishReady?.prepared_at || null,
+        prepared_by: publishReady?.prepared_by || null,
+        title: publishReady?.title || null,
+        cover_text: publishReady?.cover_text || null
+      }
+    : null;
+  const publishRecordPreview = publishRecord || draft.publish_record_id || draft.published_at || draft.published_url
+    ? {
+        publish_record_id: publishRecord?.publish_record_id || draft.publish_record_id || null,
+        platform: publishRecord?.platform || draft.published_platform || null,
+        published_at: publishRecord?.published_at || draft.published_at || null,
+        published_by: publishRecord?.published_by || draft.published_by || null,
+        platform_post_url: publishRecord?.platform_post_url || draft.published_url || null,
+        platform_post_id: publishRecord?.platform_post_id || draft.platform_post_id || null,
+        notes: publishRecord?.notes || null
+      }
+    : null;
 
   return {
     draft_id: draftId,
@@ -112,6 +138,14 @@ function buildNoteLineage(draft, briefsById, bundlesById, runsByDraftId) {
     review_updated_at: draft.review_updated_at || null,
     review_history_count: Array.isArray(draft.review_history) ? draft.review_history.length : 0,
     review_transition_rules: draft.review_transition_rules || null,
+    has_publish_ready: Boolean(publishReadyPreview),
+    has_publish_record: Boolean(publishRecordPreview),
+    publish_ready: publishReadyPreview,
+    publish_record: publishRecordPreview,
+    publish_ready_id: publishReadyPreview?.publish_ready_id || null,
+    publish_record_id: publishRecordPreview?.publish_record_id || null,
+    published_at: publishRecordPreview?.published_at || draft.published_at || null,
+    published_url: publishRecordPreview?.platform_post_url || draft.published_url || null,
     created_at: draft.created_at,
     source_post_count: (draft.source_posts || []).length,
     bundle_preview: bundle
@@ -161,6 +195,8 @@ function buildDashboardData(projectRoot = path.resolve(__dirname, '..')) {
   const notesDraftsRoot = path.join(projectRoot, 'notes', 'drafts');
   const notesBriefsRoot = path.join(projectRoot, 'notes', 'briefs');
   const notesBundlesRoot = path.join(projectRoot, 'notes', 'bundles');
+  const notesPublishReadyRoot = path.join(projectRoot, 'notes', 'publish-ready');
+  const notesPublishRecordsRoot = path.join(projectRoot, 'notes', 'publish-records');
   const notesRunsRoot = path.join(projectRoot, 'notes', 'runs');
 
   const handles = fs.existsSync(accountsRoot)
@@ -181,9 +217,13 @@ function buildDashboardData(projectRoot = path.resolve(__dirname, '..')) {
   const noteDrafts = readJsonDir(notesDraftsRoot);
   const noteBriefs = readJsonDir(notesBriefsRoot);
   const noteBundles = readJsonDir(notesBundlesRoot);
+  const publishReadyPayloads = readJsonDir(notesPublishReadyRoot);
+  const publishRecords = readJsonDir(notesPublishRecordsRoot);
   const noteRuns = readJsonDir(notesRunsRoot);
   const briefsById = indexById(noteBriefs, (item) => item.brief_id);
   const bundlesById = indexById(noteBundles, (item) => item.bundle_id || item.selection_id);
+  const publishReadyByDraftId = indexById(publishReadyPayloads, (item) => item.draft_id);
+  const publishRecordsByDraftId = indexById(publishRecords, (item) => item.draft_id);
   const runsByDraftId = indexById(noteRuns, (item) => item.draft_id);
   const originalsOnly = sortedPosts.filter((p) => p.content_type === 'original');
   const contentTypeCounts = sortedPosts.reduce((acc, post) => {
@@ -196,7 +236,14 @@ function buildDashboardData(projectRoot = path.resolve(__dirname, '..')) {
   const todayPosts = sortedPosts.filter((p) => (p.created_at || '').slice(0, 10) === todayStr);
   const topLiked = [...sortedPosts].sort((a, b) => safeNum(b.metrics?.like) - safeNum(a.metrics?.like)).slice(0, 20);
   const topViewed = [...sortedPosts].sort((a, b) => safeNum(b.metrics?.view) - safeNum(a.metrics?.view)).slice(0, 20);
-  const notes = noteDrafts.map((draft) => buildNoteLineage(draft, briefsById, bundlesById, runsByDraftId));
+  const notes = noteDrafts.map((draft) => buildNoteLineage(
+    draft,
+    briefsById,
+    bundlesById,
+    runsByDraftId,
+    publishReadyByDraftId,
+    publishRecordsByDraftId
+  ));
 
   const dashboard = {
     generated_at: new Date().toISOString(),

--- a/test/dashboard_data.test.js
+++ b/test/dashboard_data.test.js
@@ -46,3 +46,52 @@ test('build_dashboard_data degrades gracefully when brief/bundle are missing', (
   assert.equal(dashboard.notes[0].bundle_preview, null);
   assert.ok(dashboard.filters_meta.review_statuses.includes('reviewing'));
 });
+
+test('build_dashboard_data includes publish-ready and publish-record traceability when artifacts exist', () => {
+  const repoRoot = path.resolve(__dirname, '..');
+  const tempRoot = makeTempProject();
+  copyFile(path.join(repoRoot, 'scripts', 'build_dashboard_data.js'), path.join(tempRoot, 'scripts', 'build_dashboard_data.js'));
+
+  writeJson(path.join(tempRoot, 'notes', 'drafts', 'draft-2.json'), {
+    draft_id: 'draft-2',
+    brief_id: 'brief-2',
+    bundle_id: 'bundle-2',
+    theme: 'AI coding',
+    style: 'trend-analysis',
+    body_markdown: 'hello',
+    source_posts: [],
+    status: 'draft',
+    review_status: 'published',
+    publish_ready_id: 'publish-ready-draft-2',
+    publish_record_id: 'publish-1742883600000',
+    published_at: '2026-03-25T11:00:00.000Z',
+    published_url: 'https://www.xiaohongshu.com/explore/demo',
+    created_at: '2026-03-24T10:00:00.000Z'
+  });
+  writeJson(path.join(tempRoot, 'notes', 'publish-ready', 'draft-2.json'), {
+    publish_ready_id: 'publish-ready-draft-2',
+    draft_id: 'draft-2',
+    prepared_at: '2026-03-25T10:00:00.000Z',
+    prepared_by: 'xiangbaqiu',
+    title: '准备发布标题'
+  });
+  writeJson(path.join(tempRoot, 'notes', 'publish-records', 'publish-1742883600000.json'), {
+    publish_record_id: 'publish-1742883600000',
+    draft_id: 'draft-2',
+    platform: 'xiaohongshu',
+    published_at: '2026-03-25T11:00:00.000Z',
+    published_by: 'xiangbaqiu',
+    platform_post_url: 'https://www.xiaohongshu.com/explore/demo'
+  });
+
+  execFileSync('node', [path.join(tempRoot, 'scripts', 'build_dashboard_data.js')], { cwd: tempRoot, encoding: 'utf8' });
+  const dashboard = JSON.parse(fs.readFileSync(path.join(tempRoot, 'data', 'dashboard', 'dashboard-data.json'), 'utf8'));
+  assert.equal(dashboard.notes.length, 1);
+  assert.equal(dashboard.notes[0].has_publish_ready, true);
+  assert.equal(dashboard.notes[0].has_publish_record, true);
+  assert.equal(dashboard.notes[0].publish_ready.publish_ready_id, 'publish-ready-draft-2');
+  assert.equal(dashboard.notes[0].publish_ready.prepared_by, 'xiangbaqiu');
+  assert.equal(dashboard.notes[0].publish_record.publish_record_id, 'publish-1742883600000');
+  assert.equal(dashboard.notes[0].publish_record.platform_post_url, 'https://www.xiaohongshu.com/explore/demo');
+  assert.equal(dashboard.notes[0].published_url, 'https://www.xiaohongshu.com/explore/demo');
+});


### PR DESCRIPTION
## Summary
- include publish-ready and publish-record artifacts in dashboard note data
- render a publish traceability block in the dashboard note card
- cover publish traceability in dashboard data tests and verify with a browser smoke check

## Testing
- node --test

Closes #26
