### PR TITLE
feat: add dashboard publish-ready action

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ python3 -m http.server 8008
 
 `http://127.0.0.1:8008/dashboard/index.html`
 
-如果要在 dashboard 里直接做审核状态流转，请使用可写模式：
+如果要在 dashboard 里直接做审核状态流转、生成 publish-ready payload，请使用可写模式：
 
 ```bash
 node scripts/dashboard_server.js

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,7 +166,7 @@ python3 -m http.server 8008
 
 `http://127.0.0.1:8008/dashboard/index.html`
 
-如果要在 dashboard 中直接做审核状态流转，请使用可写模式：
+如果要在 dashboard 中直接做审核状态流转、生成 publish-ready payload，请使用可写模式：
 
 ```bash
 node scripts/dashboard_server.js

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -257,6 +257,27 @@ function renderReviewActions(note) {
   `;
 }
 
+function renderPublishReadyAction(note) {
+  if (!appState.apiAvailable || note.review_status !== 'approved') {
+    return '';
+  }
+
+  const label = note.has_publish_ready ? '重新生成发布包' : '生成发布包';
+
+  return `
+    <div class="review-actions publish-actions">
+      <button
+        type="button"
+        class="publish-ready-action"
+        data-draft-id="${note.draft_id}"
+        ${appState.pendingDraftId === note.draft_id ? 'disabled' : ''}
+      >
+        ${label}
+      </button>
+    </div>
+  `;
+}
+
 function renderNotes(notes) {
   document.getElementById('notesList').innerHTML = (notes || [])
     .map((note) => `
@@ -268,6 +289,7 @@ function renderNotes(notes) {
         <div class="note-tags">来源帖子数：${note.source_post_count || 0} · 标签：${(note.hashtags || []).join(' ')}</div>
         ${renderReviewAnnotationForm(note)}
         ${renderReviewActions(note)}
+        ${renderPublishReadyAction(note)}
         ${renderReviewAnnotation(note)}
         ${renderPublishTraceability(note)}
         ${note.bundle_preview ? `
@@ -497,11 +519,49 @@ async function updateReviewStatus(draftId, reviewStatus) {
   }
 }
 
-document.getElementById('notesList').addEventListener('click', async (event) => {
-  const button = event.target.closest('.review-action');
-  if (!button) return;
+async function createPublishReadyAction(draftId) {
+  appState.pendingDraftId = draftId;
+  appState.feedback = '正在生成发布包…';
+  renderFeedback();
+  renderNotesFromState();
 
-  await updateReviewStatus(button.dataset.draftId, button.dataset.reviewStatus);
+  try {
+    const response = await fetch(`/api/drafts/${encodeURIComponent(draftId)}/publish-ready`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        operator_identity: appState.noteForms[draftId]?.operatorIdentity || ''
+      })
+    });
+    const payload = await response.json();
+    if (!response.ok || !payload.ok) {
+      throw new Error(payload.message || '发布包生成失败');
+    }
+
+    appState.feedback = `已生成 ${draftId} 的发布包`;
+    const data = await loadDashboardData();
+    renderDashboard(data);
+  } catch (error) {
+    appState.feedback = `发布包生成失败：${error.message}`;
+    renderFeedback();
+  } finally {
+    appState.pendingDraftId = null;
+    renderNotesFromState();
+    renderFeedback();
+  }
+}
+
+document.getElementById('notesList').addEventListener('click', async (event) => {
+  const reviewButton = event.target.closest('.review-action');
+  if (reviewButton) {
+    await updateReviewStatus(reviewButton.dataset.draftId, reviewButton.dataset.reviewStatus);
+    return;
+  }
+
+  const publishReadyButton = event.target.closest('.publish-ready-action');
+  if (publishReadyButton) {
+    await createPublishReadyAction(publishReadyButton.dataset.draftId);
+  }
 });
 
 document.getElementById('notesList').addEventListener('input', (event) => {

--- a/scripts/dashboard_server.js
+++ b/scripts/dashboard_server.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const http = require('http');
 const path = require('path');
 const { buildDashboardData } = require('./build_dashboard_data');
+const { createPublishReady } = require('../src/publish_ready_builder');
 const { updateDraftReviewStatus } = require('../src/review_action_store');
 
 function sendJson(res, statusCode, payload) {
@@ -97,6 +98,29 @@ function createDashboardServer(projectRoot) {
           review_status: draft.review_status,
           review_annotation: draft.review_annotation || null,
           review_updated_at: draft.review_updated_at,
+          dashboard_generated_at: dashboard.generated_at
+        });
+      } catch (error) {
+        return sendJson(res, 400, { ok: false, message: error.message });
+      }
+    }
+
+    if (req.method === 'POST' && /^\/api\/drafts\/[^/]+\/publish-ready$/.test(url.pathname)) {
+      try {
+        const draftId = decodeURIComponent(url.pathname.split('/')[3]);
+        const body = await readBody(req);
+        const { publishReady, filePath } = createPublishReady(projectRoot, {
+          draftId,
+          preparedBy: body.operator_identity
+        });
+        const { dashboard } = buildDashboardData(projectRoot);
+        return sendJson(res, 200, {
+          ok: true,
+          draft_id: draftId,
+          publish_ready_id: publishReady.publish_ready_id,
+          prepared_at: publishReady.prepared_at,
+          prepared_by: publishReady.prepared_by,
+          artifact_path: path.relative(projectRoot, filePath),
           dashboard_generated_at: dashboard.generated_at
         });
       } catch (error) {

--- a/test/dashboard_server.test.js
+++ b/test/dashboard_server.test.js
@@ -75,3 +75,107 @@ test('dashboard server updates review status, annotations, and rebuilds dashboar
     await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
   }
 });
+
+test('dashboard server creates publish-ready payload and rebuilds dashboard data', async () => {
+  const tempRoot = makeTempProject();
+  writeText(path.join(tempRoot, 'dashboard', 'index.html'), '<!doctype html><title>ok</title>');
+  writeText(path.join(tempRoot, 'dashboard', 'app.js'), 'console.log("ok");');
+  writeText(path.join(tempRoot, 'dashboard', 'styles.css'), 'body {}');
+
+  writeJson(path.join(tempRoot, 'notes', 'drafts', 'draft-2.json'), {
+    draft_id: 'draft-2',
+    brief_id: 'brief-2',
+    bundle_id: 'bundle-2',
+    theme: 'AI coding',
+    style: 'trend-analysis',
+    title_options: ['可直接发布的标题'],
+    cover_text_options: ['封面文案'],
+    body_markdown: 'hello publish ready',
+    hashtags: ['#AI', '#内容运营'],
+    source_posts: [],
+    status: 'draft',
+    review_status: 'approved',
+    review_annotation: {
+      operator_identity: 'xiangbaqiu',
+      reviewer_note: '可以进入发布准备'
+    },
+    created_at: '2026-03-24T10:00:00.000Z'
+  });
+
+  const server = createDashboardServer(tempRoot);
+  await new Promise((resolve) => server.listen(0, resolve));
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/drafts/draft-2/publish-ready`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        operator_identity: 'xiangbaqiu'
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.draft_id, 'draft-2');
+    assert.equal(payload.publish_ready_id, 'publish-ready-draft-2');
+    assert.equal(payload.prepared_by, 'xiangbaqiu');
+
+    const publishReady = JSON.parse(fs.readFileSync(path.join(tempRoot, 'notes', 'publish-ready', 'draft-2.json'), 'utf8'));
+    const dashboard = JSON.parse(fs.readFileSync(path.join(tempRoot, 'data', 'dashboard', 'dashboard-data.json'), 'utf8'));
+
+    assert.equal(publishReady.publish_ready_id, 'publish-ready-draft-2');
+    assert.equal(publishReady.prepared_by, 'xiangbaqiu');
+    assert.equal(publishReady.title, '可直接发布的标题');
+    assert.equal(publishReady.cover_text, '封面文案');
+    assert.deepEqual(publishReady.hashtags, ['#AI', '#内容运营']);
+    assert.equal(dashboard.notes[0].has_publish_ready, true);
+    assert.equal(dashboard.notes[0].publish_ready.publish_ready_id, 'publish-ready-draft-2');
+    assert.equal(dashboard.notes[0].publish_ready.prepared_by, 'xiangbaqiu');
+  } finally {
+    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  }
+});
+
+test('dashboard server rejects publish-ready generation for non-approved drafts', async () => {
+  const tempRoot = makeTempProject();
+  writeText(path.join(tempRoot, 'dashboard', 'index.html'), '<!doctype html><title>ok</title>');
+  writeText(path.join(tempRoot, 'dashboard', 'app.js'), 'console.log("ok");');
+  writeText(path.join(tempRoot, 'dashboard', 'styles.css'), 'body {}');
+
+  writeJson(path.join(tempRoot, 'notes', 'drafts', 'draft-3.json'), {
+    draft_id: 'draft-3',
+    brief_id: 'brief-3',
+    bundle_id: 'bundle-3',
+    theme: 'AI coding',
+    style: 'trend-analysis',
+    body_markdown: 'not approved yet',
+    source_posts: [],
+    status: 'draft',
+    review_status: 'reviewing',
+    created_at: '2026-03-24T10:00:00.000Z'
+  });
+
+  const server = createDashboardServer(tempRoot);
+  await new Promise((resolve) => server.listen(0, resolve));
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/drafts/draft-3/publish-ready`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        operator_identity: 'xiangbaqiu'
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.ok, false);
+    assert.match(payload.message, /not approved/i);
+    assert.equal(fs.existsSync(path.join(tempRoot, 'notes', 'publish-ready', 'draft-3.json')), false);
+  } finally {
+    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  }
+});


### PR DESCRIPTION
## Summary
- add a dashboard server endpoint that reuses `publish_ready_builder`
- add a dashboard action for approved drafts to generate publish-ready payloads
- cover the new flow with server tests and update dashboard usage docs

## Testing
- `node --test`
- browser smoke for dashboard generate publish-ready action

Closes #30