### PR TITLE
feat: add dashboard publish record action

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ python3 -m http.server 8008
 
 `http://127.0.0.1:8008/dashboard/index.html`
 
-如果要在 dashboard 里直接做审核状态流转、生成 publish-ready payload，请使用可写模式：
+如果要在 dashboard 里直接做审核状态流转、生成 publish-ready payload、记录 published 结果，请使用可写模式：
 
 ```bash
 node scripts/dashboard_server.js

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,7 +166,7 @@ python3 -m http.server 8008
 
 `http://127.0.0.1:8008/dashboard/index.html`
 
-如果要在 dashboard 中直接做审核状态流转、生成 publish-ready payload，请使用可写模式：
+如果要在 dashboard 中直接做审核状态流转、生成 publish-ready payload、记录 published 结果，请使用可写模式：
 
 ```bash
 node scripts/dashboard_server.js

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -155,7 +155,11 @@ function getNoteFormState(note) {
     reviewerNote: note.review_annotation?.reviewer_note || '',
     editSuggestion: note.review_annotation?.edit_suggestion || '',
     rejectionReason: note.review_annotation?.rejection_reason || '',
-    operatorIdentity: note.review_annotation?.operator_identity || ''
+    operatorIdentity: note.review_annotation?.operator_identity || '',
+    publishedAt: note.publish_record?.published_at || '',
+    platformUrl: note.publish_record?.platform_post_url || note.published_url || '',
+    platformPostId: note.publish_record?.platform_post_id || '',
+    publishNote: note.publish_record?.notes || ''
   };
 }
 
@@ -179,7 +183,7 @@ function renderReviewAnnotation(note) {
 }
 
 function renderReviewAnnotationForm(note) {
-  if (!appState.apiAvailable) return '';
+  if (!appState.apiAvailable || note.review_status === 'published') return '';
 
   const form = getNoteFormState(note);
 
@@ -229,6 +233,10 @@ function renderReviewAnnotationForm(note) {
 }
 
 function renderReviewActions(note) {
+  if (note.review_status === 'published') {
+    return '';
+  }
+
   if (!appState.apiAvailable) {
     return '<div class="review-actions hint">当前是只读模式。请用 `node scripts/dashboard_server.js` 打开 dashboard 以启用审核操作。</div>';
   }
@@ -278,6 +286,70 @@ function renderPublishReadyAction(note) {
   `;
 }
 
+function renderPublishRecordForm(note) {
+  if (!appState.apiAvailable || note.review_status !== 'approved' || !note.has_publish_ready) {
+    return '';
+  }
+
+  const form = getNoteFormState(note);
+
+  return `
+    <div class="review-form publish-record-form">
+      <div class="review-form-grid">
+        <label class="review-field">
+          <span>发布时间</span>
+          <input
+            class="review-input"
+            data-draft-id="${note.draft_id}"
+            data-field="publishedAt"
+            placeholder="可选，默认当前时间"
+            value="${formValue(form.publishedAt)}"
+          />
+        </label>
+        <label class="review-field review-field-wide">
+          <span>平台链接</span>
+          <input
+            class="review-input"
+            data-draft-id="${note.draft_id}"
+            data-field="platformUrl"
+            placeholder="必填，例如 https://www.xiaohongshu.com/explore/<note_id>"
+            value="${formValue(form.platformUrl)}"
+          />
+        </label>
+        <label class="review-field">
+          <span>平台 ID</span>
+          <input
+            class="review-input"
+            data-draft-id="${note.draft_id}"
+            data-field="platformPostId"
+            placeholder="可选，便于追踪"
+            value="${formValue(form.platformPostId)}"
+          />
+        </label>
+        <label class="review-field review-field-wide">
+          <span>发布备注</span>
+          <textarea
+            class="review-input review-textarea"
+            data-draft-id="${note.draft_id}"
+            data-field="publishNote"
+            placeholder="可选，记录发布时间或补充说明"
+          >${formValue(form.publishNote)}</textarea>
+        </label>
+      </div>
+      <div class="review-actions publish-actions">
+        <button
+          type="button"
+          class="publish-record-action"
+          data-draft-id="${note.draft_id}"
+          ${appState.pendingDraftId === note.draft_id ? 'disabled' : ''}
+        >
+          记录已发布
+        </button>
+      </div>
+    </div>
+  `;
+}
+
 function renderNotes(notes) {
   document.getElementById('notesList').innerHTML = (notes || [])
     .map((note) => `
@@ -290,6 +362,7 @@ function renderNotes(notes) {
         ${renderReviewAnnotationForm(note)}
         ${renderReviewActions(note)}
         ${renderPublishReadyAction(note)}
+        ${renderPublishRecordForm(note)}
         ${renderReviewAnnotation(note)}
         ${renderPublishTraceability(note)}
         ${note.bundle_preview ? `
@@ -367,7 +440,11 @@ function syncNoteForms(data) {
       reviewerNote: note.review_annotation?.reviewer_note || '',
       editSuggestion: note.review_annotation?.edit_suggestion || '',
       rejectionReason: note.review_annotation?.rejection_reason || '',
-      operatorIdentity: note.review_annotation?.operator_identity || ''
+      operatorIdentity: note.review_annotation?.operator_identity || '',
+      publishedAt: note.publish_record?.published_at || '',
+      platformUrl: note.publish_record?.platform_post_url || note.published_url || '',
+      platformPostId: note.publish_record?.platform_post_id || '',
+      publishNote: note.publish_record?.notes || ''
     }
   ]));
 }
@@ -551,6 +628,42 @@ async function createPublishReadyAction(draftId) {
   }
 }
 
+async function createPublishRecordAction(draftId) {
+  appState.pendingDraftId = draftId;
+  appState.feedback = '正在记录发布结果…';
+  renderFeedback();
+  renderNotesFromState();
+
+  try {
+    const response = await fetch(`/api/drafts/${encodeURIComponent(draftId)}/publish-record`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        operator_identity: appState.noteForms[draftId]?.operatorIdentity || '',
+        published_at: appState.noteForms[draftId]?.publishedAt || '',
+        platform_url: appState.noteForms[draftId]?.platformUrl || '',
+        platform_post_id: appState.noteForms[draftId]?.platformPostId || '',
+        publish_note: appState.noteForms[draftId]?.publishNote || ''
+      })
+    });
+    const payload = await response.json();
+    if (!response.ok || !payload.ok) {
+      throw new Error(payload.message || '发布结果记录失败');
+    }
+
+    appState.feedback = `已记录 ${draftId} 的发布结果`;
+    const data = await loadDashboardData();
+    renderDashboard(data);
+  } catch (error) {
+    appState.feedback = `发布结果记录失败：${error.message}`;
+    renderFeedback();
+  } finally {
+    appState.pendingDraftId = null;
+    renderNotesFromState();
+    renderFeedback();
+  }
+}
+
 document.getElementById('notesList').addEventListener('click', async (event) => {
   const reviewButton = event.target.closest('.review-action');
   if (reviewButton) {
@@ -561,6 +674,12 @@ document.getElementById('notesList').addEventListener('click', async (event) => 
   const publishReadyButton = event.target.closest('.publish-ready-action');
   if (publishReadyButton) {
     await createPublishReadyAction(publishReadyButton.dataset.draftId);
+    return;
+  }
+
+  const publishRecordButton = event.target.closest('.publish-record-action');
+  if (publishRecordButton) {
+    await createPublishRecordAction(publishRecordButton.dataset.draftId);
   }
 });
 

--- a/scripts/dashboard_server.js
+++ b/scripts/dashboard_server.js
@@ -4,6 +4,7 @@ const http = require('http');
 const path = require('path');
 const { buildDashboardData } = require('./build_dashboard_data');
 const { createPublishReady } = require('../src/publish_ready_builder');
+const { recordPublishResult } = require('../src/publish_record_store');
 const { updateDraftReviewStatus } = require('../src/review_action_store');
 
 function sendJson(res, statusCode, payload) {
@@ -121,6 +122,36 @@ function createDashboardServer(projectRoot) {
           prepared_at: publishReady.prepared_at,
           prepared_by: publishReady.prepared_by,
           artifact_path: path.relative(projectRoot, filePath),
+          dashboard_generated_at: dashboard.generated_at
+        });
+      } catch (error) {
+        return sendJson(res, 400, { ok: false, message: error.message });
+      }
+    }
+
+    if (req.method === 'POST' && /^\/api\/drafts\/[^/]+\/publish-record$/.test(url.pathname)) {
+      try {
+        const draftId = decodeURIComponent(url.pathname.split('/')[3]);
+        const body = await readBody(req);
+        const { draft, publishRecord, publishRecordPath } = recordPublishResult(projectRoot, {
+          draftId,
+          publishedBy: body.operator_identity,
+          publishedAt: body.published_at,
+          platformUrl: body.platform_url,
+          platformPostId: body.platform_post_id,
+          note: body.publish_note,
+          source: 'dashboard'
+        });
+        const { dashboard } = buildDashboardData(projectRoot);
+        return sendJson(res, 200, {
+          ok: true,
+          draft_id: draftId,
+          review_status: draft.review_status,
+          publish_record_id: publishRecord.publish_record_id,
+          published_at: publishRecord.published_at,
+          published_by: publishRecord.published_by,
+          platform_post_url: publishRecord.platform_post_url,
+          artifact_path: path.relative(projectRoot, publishRecordPath),
           dashboard_generated_at: dashboard.generated_at
         });
       } catch (error) {

--- a/test/dashboard_server.test.js
+++ b/test/dashboard_server.test.js
@@ -179,3 +179,133 @@ test('dashboard server rejects publish-ready generation for non-approved drafts'
     await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
   }
 });
+
+test('dashboard server records publish result, updates draft, and rebuilds dashboard data', async () => {
+  const tempRoot = makeTempProject();
+  writeText(path.join(tempRoot, 'dashboard', 'index.html'), '<!doctype html><title>ok</title>');
+  writeText(path.join(tempRoot, 'dashboard', 'app.js'), 'console.log("ok");');
+  writeText(path.join(tempRoot, 'dashboard', 'styles.css'), 'body {}');
+
+  writeJson(path.join(tempRoot, 'notes', 'drafts', 'draft-4.json'), {
+    draft_id: 'draft-4',
+    brief_id: 'brief-4',
+    bundle_id: 'bundle-4',
+    theme: 'AI coding',
+    style: 'trend-analysis',
+    body_markdown: 'ready to publish',
+    source_posts: [],
+    status: 'draft',
+    review_status: 'approved',
+    created_at: '2026-03-24T10:00:00.000Z'
+  });
+  writeJson(path.join(tempRoot, 'notes', 'publish-ready', 'draft-4.json'), {
+    publish_ready_id: 'publish-ready-draft-4',
+    draft_id: 'draft-4',
+    brief_id: 'brief-4',
+    bundle_id: 'bundle-4',
+    title: '可发布标题',
+    cover_text: '可发布封面',
+    body_markdown: 'ready to publish',
+    hashtags: ['#AI'],
+    prepared_at: '2026-03-24T10:05:00.000Z',
+    prepared_by: 'xiangbaqiu',
+    source_review_status: 'approved'
+  });
+
+  const server = createDashboardServer(tempRoot);
+  await new Promise((resolve) => server.listen(0, resolve));
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/drafts/draft-4/publish-record`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        operator_identity: 'xiangbaqiu',
+        published_at: '2026-03-25T12:30:00.000Z',
+        platform_url: 'https://www.xiaohongshu.com/explore/abc123',
+        platform_post_id: 'abc123',
+        publish_note: '已手动发出'
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.draft_id, 'draft-4');
+    assert.equal(payload.review_status, 'published');
+    assert.equal(payload.published_by, 'xiangbaqiu');
+    assert.equal(payload.platform_post_url, 'https://www.xiaohongshu.com/explore/abc123');
+
+    const persistedDraft = JSON.parse(fs.readFileSync(path.join(tempRoot, 'notes', 'drafts', 'draft-4.json'), 'utf8'));
+    const publishRecordsDir = path.join(tempRoot, 'notes', 'publish-records');
+    const publishRecordFiles = fs.readdirSync(publishRecordsDir).filter((file) => file.endsWith('.json'));
+    const publishRecord = JSON.parse(fs.readFileSync(path.join(publishRecordsDir, publishRecordFiles[0]), 'utf8'));
+    const dashboard = JSON.parse(fs.readFileSync(path.join(tempRoot, 'data', 'dashboard', 'dashboard-data.json'), 'utf8'));
+
+    assert.equal(persistedDraft.review_status, 'published');
+    assert.equal(persistedDraft.publish_record_id, publishRecord.publish_record_id);
+    assert.equal(persistedDraft.published_url, 'https://www.xiaohongshu.com/explore/abc123');
+    assert.equal(persistedDraft.review_annotation.operator_identity, 'xiangbaqiu');
+    assert.equal(publishRecord.publish_ready_id, 'publish-ready-draft-4');
+    assert.equal(publishRecord.platform_post_id, 'abc123');
+    assert.equal(publishRecord.notes, '已手动发出');
+    assert.equal(dashboard.notes[0].review_status, 'published');
+    assert.equal(dashboard.notes[0].has_publish_record, true);
+    assert.equal(dashboard.notes[0].publish_record.platform_post_url, 'https://www.xiaohongshu.com/explore/abc123');
+  } finally {
+    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  }
+});
+
+test('dashboard server rejects publish record when platform url is missing', async () => {
+  const tempRoot = makeTempProject();
+  writeText(path.join(tempRoot, 'dashboard', 'index.html'), '<!doctype html><title>ok</title>');
+  writeText(path.join(tempRoot, 'dashboard', 'app.js'), 'console.log("ok");');
+  writeText(path.join(tempRoot, 'dashboard', 'styles.css'), 'body {}');
+
+  writeJson(path.join(tempRoot, 'notes', 'drafts', 'draft-5.json'), {
+    draft_id: 'draft-5',
+    brief_id: 'brief-5',
+    bundle_id: 'bundle-5',
+    theme: 'AI coding',
+    style: 'trend-analysis',
+    body_markdown: 'ready to publish',
+    source_posts: [],
+    status: 'draft',
+    review_status: 'approved',
+    created_at: '2026-03-24T10:00:00.000Z'
+  });
+  writeJson(path.join(tempRoot, 'notes', 'publish-ready', 'draft-5.json'), {
+    publish_ready_id: 'publish-ready-draft-5',
+    draft_id: 'draft-5',
+    title: '可发布标题',
+    body_markdown: 'ready to publish',
+    hashtags: [],
+    prepared_at: '2026-03-24T10:05:00.000Z',
+    source_review_status: 'approved'
+  });
+
+  const server = createDashboardServer(tempRoot);
+  await new Promise((resolve) => server.listen(0, resolve));
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/drafts/draft-5/publish-record`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        operator_identity: 'xiangbaqiu',
+        publish_note: '少了平台链接'
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.ok, false);
+    assert.match(payload.message, /platformUrl is required/i);
+    assert.equal(fs.existsSync(path.join(tempRoot, 'notes', 'publish-records')), false);
+  } finally {
+    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  }
+});


### PR DESCRIPTION
## Summary
- add a dashboard server endpoint that reuses `publish_record_store`
- add a dashboard form/action to record published results from approved drafts
- hide review editing controls after a draft is marked published and update writable-dashboard docs

## Testing
- `node --test`
- browser smoke for dashboard record-published action

Closes #31